### PR TITLE
Add initial Contifico WooCommerce plugin structure

### DIFF
--- a/wp-content/plugins/contifico-woocommerce/admin/class-admin.php
+++ b/wp-content/plugins/contifico-woocommerce/admin/class-admin.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Funcionalidades del área de administración del plugin.
+ *
+ * @package Contifico_WooCommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Clase responsable de la interacción del plugin en el escritorio.
+ */
+class Contifico_WooCommerce_Admin {
+
+    /**
+     * Versión del plugin.
+     *
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * Instancia del gestor de ajustes.
+     *
+     * @var Contifico_WooCommerce_Admin_Settings
+     */
+    protected $settings;
+
+    /**
+     * Constructor.
+     *
+     * @param string                                $version  Versión actual del plugin.
+     * @param Contifico_WooCommerce_Admin_Settings  $settings Gestor de ajustes.
+     */
+    public function __construct( $version, Contifico_WooCommerce_Admin_Settings $settings ) {
+        $this->version  = $version;
+        $this->settings = $settings;
+    }
+
+    /**
+     * Registra los hooks que se utilizarán en el panel de administración.
+     *
+     * @return void
+     */
+    public function init_hooks() {
+        add_action( 'admin_notices', array( $this, 'maybe_render_credentials_notice' ) );
+        add_filter( 'woocommerce_order_actions', array( $this, 'register_order_action' ) );
+        add_action( 'woocommerce_order_action_contifico_sync', array( $this, 'process_manual_sync' ), 10, 1 );
+    }
+
+    /**
+     * Agrega una acción personalizada en la pantalla de pedidos de WooCommerce.
+     *
+     * @param array $actions Lista de acciones disponibles.
+     *
+     * @return array
+     */
+    public function register_order_action( $actions ) {
+        $actions['contifico_sync'] = __( 'Sincronizar con Contifico', 'contifico-woocommerce' );
+
+        return $actions;
+    }
+
+    /**
+     * Ejecuta la lógica de sincronización cuando se selecciona la acción manual.
+     *
+     * @param mixed $order Pedido que se va a sincronizar.
+     *
+     * @return void
+     */
+    public function process_manual_sync( $order ) {
+        if ( is_numeric( $order ) ) {
+            $order = wc_get_order( $order );
+        }
+
+        if ( ! $order instanceof WC_Order ) {
+            return;
+        }
+
+        do_action( 'contifico_woocommerce_manual_order_sync', $order );
+    }
+
+    /**
+     * Muestra una advertencia cuando faltan credenciales para la API.
+     *
+     * @return void
+     */
+    public function maybe_render_credentials_notice() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            return;
+        }
+
+        if ( $this->settings->has_credentials() ) {
+            return;
+        }
+
+        $screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+        if ( ! $screen || false === strpos( $screen->id, 'woocommerce' ) ) {
+            return;
+        }
+
+        $settings_url = admin_url( 'admin.php?page=contifico-woocommerce' );
+
+        echo '<div class="notice notice-warning"><p>';
+        printf(
+            /* translators: %s URL hacia la página de ajustes del plugin. */
+            esc_html__( 'Configura las credenciales de Contifico para habilitar la sincronización. %s.', 'contifico-woocommerce' ),
+            sprintf(
+                '<a href="%1$s">%2$s</a>',
+                esc_url( $settings_url ),
+                esc_html__( 'Ir a los ajustes', 'contifico-woocommerce' )
+            )
+        );
+        echo '</p></div>';
+    }
+}

--- a/wp-content/plugins/contifico-woocommerce/admin/class-settings.php
+++ b/wp-content/plugins/contifico-woocommerce/admin/class-settings.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Definición de la página de ajustes del plugin.
+ *
+ * @package Contifico_WooCommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Administra la configuración guardada en la base de datos.
+ */
+class Contifico_WooCommerce_Admin_Settings {
+
+    /**
+     * Nombre del option en la base de datos.
+     *
+     * @var string
+     */
+    protected $option_name = 'contifico_woocommerce_settings';
+
+    /**
+     * Grupo utilizado para registrar los ajustes.
+     *
+     * @var string
+     */
+    protected $option_group = 'contifico_woocommerce';
+
+    /**
+     * Inicializa los hooks necesarios para la pantalla de ajustes.
+     *
+     * @return void
+     */
+    public function init() {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+    }
+
+    /**
+     * Crea el submenú dentro de WooCommerce.
+     *
+     * @return void
+     */
+    public function register_menu() {
+        add_submenu_page(
+            'woocommerce',
+            __( 'Contifico', 'contifico-woocommerce' ),
+            __( 'Contifico', 'contifico-woocommerce' ),
+            'manage_woocommerce',
+            'contifico-woocommerce',
+            array( $this, 'render_settings_page' )
+        );
+    }
+
+    /**
+     * Registra los ajustes y campos a mostrar en la pantalla de opciones.
+     *
+     * @return void
+     */
+    public function register_settings() {
+        register_setting(
+            $this->option_group,
+            $this->option_name,
+            array( $this, 'sanitize' )
+        );
+
+        add_settings_section(
+            'contifico_woocommerce_api',
+            __( 'Credenciales de la API', 'contifico-woocommerce' ),
+            array( $this, 'render_section_description' ),
+            $this->option_group
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_api_url',
+            __( 'URL de la API', 'contifico-woocommerce' ),
+            array( $this, 'render_text_field' ),
+            $this->option_group,
+            'contifico_woocommerce_api',
+            array(
+                'label_for'   => 'contifico_woocommerce_api_url',
+                'option_key'  => 'api_url',
+                'type'        => 'url',
+                'placeholder' => 'https://',
+                'description' => __( 'Dirección base del servicio de Contifico.', 'contifico-woocommerce' ),
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_api_key',
+            __( 'API Key', 'contifico-woocommerce' ),
+            array( $this, 'render_text_field' ),
+            $this->option_group,
+            'contifico_woocommerce_api',
+            array(
+                'label_for'  => 'contifico_woocommerce_api_key',
+                'option_key' => 'api_key',
+                'type'       => 'text',
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_api_secret',
+            __( 'API Secret', 'contifico-woocommerce' ),
+            array( $this, 'render_text_field' ),
+            $this->option_group,
+            'contifico_woocommerce_api',
+            array(
+                'label_for'  => 'contifico_woocommerce_api_secret',
+                'option_key' => 'api_secret',
+                'type'       => 'password',
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_warehouse',
+            __( 'Bodega o punto de emisión', 'contifico-woocommerce' ),
+            array( $this, 'render_text_field' ),
+            $this->option_group,
+            'contifico_woocommerce_api',
+            array(
+                'label_for'   => 'contifico_woocommerce_warehouse',
+                'option_key'  => 'warehouse',
+                'type'        => 'text',
+                'description' => __( 'Identificador de la bodega donde se registrarán las ventas.', 'contifico-woocommerce' ),
+            )
+        );
+
+        add_settings_section(
+            'contifico_woocommerce_sync',
+            __( 'Parámetros de sincronización', 'contifico-woocommerce' ),
+            '__return_false',
+            $this->option_group
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_sync_statuses',
+            __( 'Estados a sincronizar', 'contifico-woocommerce' ),
+            array( $this, 'render_statuses_field' ),
+            $this->option_group,
+            'contifico_woocommerce_sync'
+        );
+    }
+
+    /**
+     * Imprime la descripción de la sección de credenciales.
+     *
+     * @return void
+     */
+    public function render_section_description() {
+        echo '<p>' . esc_html__( 'Introduce los datos proporcionados por Contifico para conectar la tienda.', 'contifico-woocommerce' ) . '</p>';
+    }
+
+    /**
+     * Renderiza un campo de texto genérico.
+     *
+     * @param array $args Argumentos recibidos desde add_settings_field.
+     *
+     * @return void
+     */
+    public function render_text_field( $args ) {
+        $defaults = array(
+            'label_for'   => '',
+            'option_key'  => '',
+            'type'        => 'text',
+            'placeholder' => '',
+            'description' => '',
+        );
+
+        $args     = wp_parse_args( $args, $defaults );
+        $settings = $this->get_settings();
+        $value    = isset( $settings[ $args['option_key'] ] ) ? $settings[ $args['option_key'] ] : '';
+
+        printf(
+            '<input type="%1$s" id="%2$s" name="%3$s[%4$s]" value="%5$s" class="regular-text" placeholder="%6$s" />',
+            esc_attr( $args['type'] ),
+            esc_attr( $args['label_for'] ),
+            esc_attr( $this->option_name ),
+            esc_attr( $args['option_key'] ),
+            esc_attr( $value ),
+            esc_attr( $args['placeholder'] )
+        );
+
+        if ( ! empty( $args['description'] ) ) {
+            printf( '<p class="description">%s</p>', esc_html( $args['description'] ) );
+        }
+    }
+
+    /**
+     * Renderiza los checkboxes para seleccionar los estados que se sincronizarán.
+     *
+     * @return void
+     */
+    public function render_statuses_field() {
+        $settings = $this->get_settings();
+        $current  = isset( $settings['sync_statuses'] ) && is_array( $settings['sync_statuses'] ) ? $settings['sync_statuses'] : array();
+        $statuses = function_exists( 'wc_get_order_statuses' ) ? wc_get_order_statuses() : array();
+
+        if ( empty( $statuses ) ) {
+            echo '<p>' . esc_html__( 'No se encontraron estados de pedido disponibles.', 'contifico-woocommerce' ) . '</p>';
+            return;
+        }
+
+        foreach ( $statuses as $status_key => $status_label ) {
+            printf(
+                '<label><input type="checkbox" name="%1$s[sync_statuses][]" value="%2$s" %3$s /> %4$s</label><br />',
+                esc_attr( $this->option_name ),
+                esc_attr( $status_key ),
+                checked( in_array( $status_key, $current, true ), true, false ),
+                esc_html( $status_label )
+            );
+        }
+    }
+
+    /**
+     * Sanea los datos antes de guardarlos en la base de datos.
+     *
+     * @param array $input Datos enviados desde el formulario.
+     *
+     * @return array
+     */
+    public function sanitize( $input ) {
+        $defaults = array(
+            'api_url'       => '',
+            'api_key'       => '',
+            'api_secret'    => '',
+            'warehouse'     => '',
+            'sync_statuses' => array(),
+        );
+
+        $input = wp_parse_args( (array) $input, $defaults );
+
+        $sanitized = array(
+            'api_url'       => esc_url_raw( $input['api_url'] ),
+            'api_key'       => sanitize_text_field( $input['api_key'] ),
+            'api_secret'    => sanitize_text_field( $input['api_secret'] ),
+            'warehouse'     => sanitize_text_field( $input['warehouse'] ),
+            'sync_statuses' => array(),
+        );
+
+        if ( ! empty( $input['sync_statuses'] ) && is_array( $input['sync_statuses'] ) ) {
+            $statuses = array_map( 'sanitize_text_field', $input['sync_statuses'] );
+            $sanitized['sync_statuses'] = array_values( array_unique( $statuses ) );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Devuelve los ajustes almacenados en la base de datos.
+     *
+     * @return array
+     */
+    public function get_settings() {
+        $defaults = array(
+            'api_url'       => '',
+            'api_key'       => '',
+            'api_secret'    => '',
+            'warehouse'     => '',
+            'sync_statuses' => array(),
+        );
+
+        $settings = get_option( $this->option_name, array() );
+
+        return wp_parse_args( $settings, $defaults );
+    }
+
+    /**
+     * Indica si existen credenciales configuradas.
+     *
+     * @return bool
+     */
+    public function has_credentials() {
+        $settings = $this->get_settings();
+
+        return ! empty( $settings['api_key'] ) && ! empty( $settings['api_secret'] );
+    }
+
+    /**
+     * Renderiza el contenido de la página de ajustes.
+     *
+     * @return void
+     */
+    public function render_settings_page() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            wp_die( esc_html__( 'No tienes permisos suficientes para acceder a esta página.', 'contifico-woocommerce' ) );
+        }
+
+        $option_group = $this->option_group;
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Integración con Contifico', 'contifico-woocommerce' ); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields( $option_group );
+                do_settings_sections( $option_group );
+                submit_button( __( 'Guardar cambios', 'contifico-woocommerce' ) );
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/wp-content/plugins/contifico-woocommerce/contifico-woocommerce.php
+++ b/wp-content/plugins/contifico-woocommerce/contifico-woocommerce.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name:       Contifico WooCommerce
+ * Plugin URI:        https://contifico.com
+ * Description:       Integración de WooCommerce con Contifico.
+ * Version:           1.0.0
+ * Author:            Contifico
+ * Author URI:        https://contifico.com
+ * License:           GPL-2.0-or-later
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:       contifico-woocommerce
+ * Domain Path:       /languages
+ *
+ * @package Contifico_WooCommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'CONTIFICO_WOOCOMMERCE_VERSION', '1.0.0' );
+define( 'CONTIFICO_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
+
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-autoloader.php';
+
+Contifico_WooCommerce_Autoloader::register();
+
+register_activation_hook( __FILE__, array( 'Contifico_WooCommerce_Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'Contifico_WooCommerce_Plugin', 'deactivate' ) );
+
+/**
+ * Inicializa la ejecución del plugin.
+ *
+ * @return void
+ */
+function contifico_woocommerce_run() {
+    $plugin = Contifico_WooCommerce_Plugin::instance();
+    $plugin->run();
+}
+
+contifico_woocommerce_run();

--- a/wp-content/plugins/contifico-woocommerce/includes/class-autoloader.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/class-autoloader.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Autoloader del plugin Contifico WooCommerce.
+ *
+ * @package Contifico_WooCommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Clase encargada de registrar el autoload de las clases del plugin.
+ */
+class Contifico_WooCommerce_Autoloader {
+
+    /**
+     * Instancia única del autoloader.
+     *
+     * @var Contifico_WooCommerce_Autoloader
+     */
+    protected static $instance;
+
+    /**
+     * Prefijo de las clases del plugin.
+     *
+     * @var string
+     */
+    protected $prefix = 'Contifico_WooCommerce_';
+
+    /**
+     * Ruta base del plugin.
+     *
+     * @var string
+     */
+    protected $base_dir;
+
+    /**
+     * Constructor privado para evitar instanciación externa.
+     */
+    private function __construct() {
+        $this->base_dir = trailingslashit( dirname( dirname( __FILE__ ) ) );
+    }
+
+    /**
+     * Registra el autoloader en SPL.
+     *
+     * @return void
+     */
+    public static function register() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        spl_autoload_register( array( self::$instance, 'autoload' ) );
+    }
+
+    /**
+     * Carga el archivo que contiene la clase solicitada.
+     *
+     * @param string $class Nombre completo de la clase solicitada.
+     *
+     * @return void
+     */
+    public function autoload( $class ) {
+        if ( 0 !== strpos( $class, $this->prefix ) ) {
+            return;
+        }
+
+        $relative_class = strtolower( str_replace( $this->prefix, '', $class ) );
+        $parts          = explode( '_', $relative_class );
+        $directory      = 'includes';
+
+        if ( isset( $parts[0] ) ) {
+            if ( 'admin' === $parts[0] ) {
+                $directory = 'admin';
+                $parts     = array_slice( $parts, 1 );
+                $parts     = ! empty( $parts ) ? $parts : array( 'admin' );
+            } elseif ( 'public' === $parts[0] ) {
+                $directory = 'public';
+                $parts     = array_slice( $parts, 1 );
+                $parts     = ! empty( $parts ) ? $parts : array( 'public' );
+            }
+        }
+
+        $filename = 'class-' . implode( '-', $parts ) . '.php';
+        $file     = $this->base_dir . $directory . '/' . $filename;
+
+        if ( file_exists( $file ) ) {
+            require_once $file;
+        }
+    }
+}

--- a/wp-content/plugins/contifico-woocommerce/includes/class-plugin.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/class-plugin.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Clase principal del plugin Contifico WooCommerce.
+ *
+ * @package Contifico_WooCommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Clase que coordina la carga de dependencias y hooks.
+ */
+class Contifico_WooCommerce_Plugin {
+
+    /**
+     * Instancia única del plugin.
+     *
+     * @var Contifico_WooCommerce_Plugin|null
+     */
+    protected static $instance = null;
+
+    /**
+     * Instancia para la parte administrativa del plugin.
+     *
+     * @var Contifico_WooCommerce_Admin
+     */
+    protected $admin;
+
+    /**
+     * Instancia para la parte pública del plugin.
+     *
+     * @var Contifico_WooCommerce_Public
+     */
+    protected $public;
+
+    /**
+     * Gestor de ajustes del plugin.
+     *
+     * @var Contifico_WooCommerce_Admin_Settings
+     */
+    protected $settings;
+
+    /**
+     * Versión actual del plugin.
+     *
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * Constructor privado para controlar la inicialización.
+     */
+    private function __construct() {
+        $this->version = defined( 'CONTIFICO_WOOCOMMERCE_VERSION' ) ? CONTIFICO_WOOCOMMERCE_VERSION : '1.0.0';
+    }
+
+    /**
+     * Obtiene la instancia singleton del plugin.
+     *
+     * @return Contifico_WooCommerce_Plugin
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Inicia los hooks base para cargar el plugin.
+     *
+     * @return void
+     */
+    public function run() {
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'plugins_loaded', array( $this, 'bootstrap' ) );
+    }
+
+    /**
+     * Carga el archivo de traducciones.
+     *
+     * @return void
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'contifico-woocommerce', false, dirname( plugin_basename( CONTIFICO_WOOCOMMERCE_PLUGIN_FILE ) ) . '/languages/' );
+    }
+
+    /**
+     * Inicializa dependencias y hooks una vez que todos los plugins están cargados.
+     *
+     * @return void
+     */
+    public function bootstrap() {
+        if ( ! $this->is_woocommerce_active() ) {
+            add_action( 'admin_notices', array( $this, 'woocommerce_missing_notice' ) );
+            return;
+        }
+
+        $this->settings = new Contifico_WooCommerce_Admin_Settings();
+        $this->admin    = new Contifico_WooCommerce_Admin( $this->version, $this->settings );
+        $this->public   = new Contifico_WooCommerce_Public( $this->version );
+
+        $this->settings->init();
+        $this->admin->init_hooks();
+        $this->public->init_hooks();
+    }
+
+    /**
+     * Muestra un aviso si WooCommerce no está disponible.
+     *
+     * @return void
+     */
+    public function woocommerce_missing_notice() {
+        if ( ! current_user_can( 'activate_plugins' ) ) {
+            return;
+        }
+
+        echo '<div class="notice notice-error"><p>';
+        esc_html_e( 'Contifico WooCommerce requiere que el plugin WooCommerce esté activo.', 'contifico-woocommerce' );
+        echo '</p></div>';
+    }
+
+    /**
+     * Comprueba si WooCommerce está activo.
+     *
+     * @return bool
+     */
+    protected function is_woocommerce_active() {
+        if ( class_exists( 'WooCommerce' ) ) {
+            return true;
+        }
+
+        if ( ! function_exists( 'is_plugin_active' ) ) {
+            include_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        return is_plugin_active( 'woocommerce/woocommerce.php' );
+    }
+
+    /**
+     * Lógica que se ejecuta al activar el plugin.
+     *
+     * @return void
+     */
+    public static function activate() {
+        if ( ! function_exists( 'is_plugin_active' ) ) {
+            include_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) && ! class_exists( 'WooCommerce' ) ) {
+            deactivate_plugins( plugin_basename( CONTIFICO_WOOCOMMERCE_PLUGIN_FILE ) );
+            wp_die( esc_html__( 'Contifico WooCommerce requiere WooCommerce para activarse.', 'contifico-woocommerce' ) );
+        }
+
+        if ( false === get_option( 'contifico_woocommerce_settings', false ) ) {
+            add_option(
+                'contifico_woocommerce_settings',
+                array(
+                    'api_url'       => '',
+                    'api_key'       => '',
+                    'api_secret'    => '',
+                    'warehouse'     => '',
+                    'sync_statuses' => array(),
+                )
+            );
+        }
+
+        update_option( 'contifico_woocommerce_version', defined( 'CONTIFICO_WOOCOMMERCE_VERSION' ) ? CONTIFICO_WOOCOMMERCE_VERSION : '1.0.0' );
+    }
+
+    /**
+     * Lógica que se ejecuta al desactivar el plugin.
+     *
+     * @return void
+     */
+    public static function deactivate() {
+        delete_option( 'contifico_woocommerce_version' );
+    }
+}

--- a/wp-content/plugins/contifico-woocommerce/public/class-public.php
+++ b/wp-content/plugins/contifico-woocommerce/public/class-public.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Funcionalidades públicas del plugin.
+ *
+ * @package Contifico_WooCommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Clase para registrar los hooks disponibles en el frontal de la tienda.
+ */
+class Contifico_WooCommerce_Public {
+
+    /**
+     * Versión del plugin.
+     *
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * Constructor.
+     *
+     * @param string $version Versión actual del plugin.
+     */
+    public function __construct( $version ) {
+        $this->version = $version;
+    }
+
+    /**
+     * Registra los hooks públicos del plugin.
+     *
+     * @return void
+     */
+    public function init_hooks() {
+        add_action( 'woocommerce_checkout_create_order', array( $this, 'mark_order_for_sync' ), 20, 2 );
+        add_action( 'woocommerce_thankyou', array( $this, 'maybe_queue_order' ), 10, 1 );
+    }
+
+    /**
+     * Marca el pedido para sincronizarse con Contifico una vez confirmado.
+     *
+     * @param WC_Order $order Pedido que se está creando.
+     * @param array    $data  Datos del checkout.
+     *
+     * @return void
+     */
+    public function mark_order_for_sync( $order, $data ) {
+        if ( ! $order instanceof WC_Order ) {
+            return;
+        }
+
+        $order->update_meta_data( '_contifico_sync_required', 'yes' );
+    }
+
+    /**
+     * Dispara un evento personalizado para manejar la sincronización del pedido.
+     *
+     * @param int $order_id Identificador del pedido completado.
+     *
+     * @return void
+     */
+    public function maybe_queue_order( $order_id ) {
+        $order_id = absint( $order_id );
+
+        if ( ! $order_id ) {
+            return;
+        }
+
+        $should_sync = get_post_meta( $order_id, '_contifico_sync_required', true );
+
+        if ( 'yes' !== $should_sync ) {
+            return;
+        }
+
+        do_action( 'contifico_woocommerce_queue_order', $order_id );
+    }
+}


### PR DESCRIPTION
## Summary
- add the Contifico WooCommerce plugin directory with the main loader file and SPL autoloader
- implement core plugin, admin, and public classes that register activation/deactivation handlers and WooCommerce hooks
- create an admin settings page to capture Contifico API credentials and synchronization parameters stored in wp_options

## Testing
- for file in wp-content/plugins/contifico-woocommerce/**/*.php; do php -l "$file" || exit 1; done
- php -l wp-content/plugins/contifico-woocommerce/contifico-woocommerce.php

------
https://chatgpt.com/codex/tasks/task_e_68d17d7b7e108332b964919a14c54d6e