### PR TITLE
Align API client with official Contifico endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# Contifico-WooCommerce
+# Contifico WooCommerce
+
+Integración base entre WooCommerce y Contifico. El plugin incluye herramientas para sincronizar productos, gestionar inventario y emitir documentos contables a través de la API de Contifico.
+
+## Cliente de API
+
+El cliente HTTP se encuentra en `includes/api/class-contifico-client.php` y encapsula la comunicación con Contifico utilizando las credenciales configuradas desde el panel de administración.
+
+### Endpoints soportados
+
+| Método | Endpoint                         | Descripción |
+| ------ | -------------------------------- | ----------- |
+| GET    | `/producto/`                      | Obtiene el catálogo de productos disponible en Contifico. |
+| GET    | `/bodega/`                        | Lista las bodegas configuradas en Contifico. |
+| POST   | `/documento/`                     | Registra un documento contable (factura, nota de venta, etc.). |
+| POST   | `/movimiento-inventario/`         | Registra un movimiento de inventario para ajustar existencias. |
+
+Todas las solicitudes se realizan contra `https://api.contifico.com/sistema/api/v1` (puede sobrescribirse en los ajustes) y envían el API Key configurado en el encabezado `Authorization`. Cada método devuelve un arreglo con la respuesta JSON de la API o un objeto `WP_Error` ante fallos. El cliente registra los errores mediante `wc_get_logger` (si está disponible) o `error_log` y reintenta automáticamente las solicitudes ante códigos HTTP temporales (`408`, `425`, `429`, `500`, `502`, `503`, `504`).
+
+El método `update_stock` crea internamente un movimiento de inventario de tipo `AJU` usando el endpoint oficial de Contifico para `movimiento-inventario`. Si no se proporciona un identificador de bodega en el payload, utilizará el valor configurado en los ajustes del plugin.
+
+## Desarrollo
+
+### Dependencias de desarrollo
+
+Instala las dependencias de Composer para ejecutar las pruebas unitarias:
+
+```bash
+composer install
+```
+
+### Pruebas
+
+El proyecto incluye pruebas básicas del cliente de API utilizando Brain\Monkey. Puedes ejecutarlas con:
+
+```bash
+composer test
+```
+
+Las pruebas se encuentran en el directorio `tests/` e incluyen dobles de WordPress para `WP_Error` y funciones comunes.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "contifico/woocommerce-integration",
+    "description": "Herramientas de desarrollo para la integración Contifico WooCommerce",
+    "type": "project",
+    "require-dev": {
+        "phpunit/phpunit": "^9.6",
+        "brain/monkey": "^2.6",
+        "mockery/mockery": "^1.5"
+    },
+    "autoload": {},
+    "autoload-dev": {
+        "psr-4": {
+            "ContificoWooCommerce\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2068 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "4fb032ab85b3dcaf17df1bcf4d9affb4",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/d95a9d895352c30f47604ad1b825ab8fa9d1a373",
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "^1.3.5 || ^1.4.4",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.26 || ^6.0 || ^7.0 || >=8.0 <8.5.12 || ^8.5.14 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/api.php"
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
+                "source": "https://github.com/Brain-WP/BrainMonkey"
+            },
+            "time": "2024-08-29T20:15:04+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+            },
+            "time": "2025-08-13T20:13:15+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.27",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0a9aa4440b6a9528cf360071502628d717af3e0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0a9aa4440b6a9528cf360071502628d717af3e0a",
+                "reference": "0a9aa4440b6a9528cf360071502628d717af3e0a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.9",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.27"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-14T06:18:03+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:51:50+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "eb49b981ef0817890129cb70f774506bebe57740"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/eb49b981ef0817890129cb70f774506bebe57740",
+                "reference": "eb49b981ef0817890129cb70f774506bebe57740",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-22T05:18:21+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:36:25+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true"
+         beStrictAboutChangesToGlobalState="false"
+         beStrictAboutOutputDuringTests="false">
+    <testsuites>
+        <testsuite name="Contifico WooCommerce Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/ContificoClientTest.php
+++ b/tests/ContificoClientTest.php
@@ -1,0 +1,206 @@
+<?php
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class ContificoClientTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        \Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_get_items_uses_default_base_url_when_not_configured() {
+        Functions\expect( 'get_option' )
+            ->once()
+            ->with( 'contifico_woocommerce_settings', array() )
+            ->andReturn(
+                array(
+                    'api_url' => '',
+                    'api_key' => 'token',
+                )
+            );
+
+        Functions\expect( 'wp_remote_request' )
+            ->once()
+            ->with(
+                'https://api.contifico.com/sistema/api/v1/producto/',
+                \Mockery::on(
+                    function ( $args ) {
+                        $this->assertSame( 'GET', $args['method'] );
+                        $this->assertSame( 'token', $args['headers']['Authorization'] );
+
+                        return true;
+                    }
+                )
+            )
+            ->andReturn( array( 'body' => '', 'response' => array( 'code' => 200 ) ) );
+
+        Functions\expect( 'wp_remote_retrieve_response_code' )
+            ->once()
+            ->with( \Mockery::type( 'array' ) )
+            ->andReturn( 200 );
+
+        Functions\expect( 'wp_remote_retrieve_body' )
+            ->once()
+            ->with( \Mockery::type( 'array' ) )
+            ->andReturn( '{"items":[]}' );
+
+        $client = new Contifico_WooCommerce_Api_Contifico_Client();
+        $result = $client->get_items();
+
+        $this->assertIsArray( $result );
+        $this->assertSame( array( 'items' => array() ), $result );
+    }
+
+    public function test_get_items_returns_data_on_success() {
+        Functions\expect( 'get_option' )
+            ->once()
+            ->with( 'contifico_woocommerce_settings', array() )
+            ->andReturn(
+                array(
+                    'api_url' => 'https://api.example.com',
+                    'api_key' => 'token-123',
+                )
+            );
+
+        Functions\expect( 'wp_remote_request' )
+            ->once()
+            ->with(
+                'https://api.example.com/producto/?page=2',
+                \Mockery::on(
+                    function ( $args ) {
+                        $this->assertSame( 'GET', $args['method'] );
+                        $this->assertSame( 'token-123', $args['headers']['Authorization'] );
+                        $this->assertSame( 'application/json', $args['headers']['Accept'] );
+
+                        return true;
+                    }
+                )
+            )
+            ->andReturn( array( 'body' => '', 'response' => array( 'code' => 200 ) ) );
+
+        Functions\expect( 'wp_remote_retrieve_response_code' )
+            ->once()
+            ->with( \Mockery::type( 'array' ) )
+            ->andReturn( 200 );
+
+        Functions\expect( 'wp_remote_retrieve_body' )
+            ->once()
+            ->with( \Mockery::type( 'array' ) )
+            ->andReturn( '{"items":[]}' );
+
+        $client = new Contifico_WooCommerce_Api_Contifico_Client();
+        $result = $client->get_items( array( 'page' => 2 ) );
+
+        $this->assertIsArray( $result );
+        $this->assertSame( array( 'items' => array() ), $result );
+    }
+
+    public function test_request_retries_on_transport_error() {
+        Functions\expect( 'get_option' )
+            ->once()
+            ->with( 'contifico_woocommerce_settings', array() )
+            ->andReturn(
+                array(
+                    'api_url' => 'https://api.example.com',
+                    'api_key' => 'token-123',
+                )
+            );
+
+        $transport_error = new WP_Error( 'http_request_failed', 'timeout' );
+
+        Functions\expect( 'wp_remote_request' )
+            ->times( 3 )
+            ->with(
+                'https://api.example.com/producto/',
+                \Mockery::on(
+                    function ( $args ) {
+                        return isset( $args['method'] ) && 'GET' === $args['method'];
+                    }
+                )
+            )
+            ->andReturn( $transport_error );
+
+        $client = new Contifico_WooCommerce_Api_Contifico_Client();
+        $result = $client->get_items();
+
+        $this->assertInstanceOf( WP_Error::class, $result );
+        $this->assertSame( 'contifico_http_request_error', $result->get_error_code() );
+    }
+
+    public function test_update_stock_sends_inventory_movement() {
+        Functions\expect( 'get_option' )
+            ->once()
+            ->with( 'contifico_woocommerce_settings', array() )
+            ->andReturn(
+                array(
+                    'api_url'   => 'https://api.example.com',
+                    'api_key'   => 'token-123',
+                    'warehouse' => 'bodega-001',
+                )
+            );
+
+        $captured_args = null;
+
+        $expected_date = gmdate( 'd/m/Y' );
+
+        Functions\expect( 'wp_remote_request' )
+            ->once()
+            ->with(
+                'https://api.example.com/movimiento-inventario/',
+                \Mockery::on(
+                    function ( $args ) use ( &$captured_args ) {
+                        $captured_args = $args;
+
+                        return isset( $args['method'], $args['headers']['Authorization'] )
+                            && 'POST' === $args['method']
+                            && 'token-123' === $args['headers']['Authorization'];
+                    }
+                )
+            )
+            ->andReturn( array( 'body' => '', 'response' => array( 'code' => 200 ) ) );
+
+        Functions\expect( 'wp_remote_retrieve_response_code' )
+            ->once()
+            ->with( \Mockery::type( 'array' ) )
+            ->andReturn( 200 );
+
+        Functions\expect( 'wp_remote_retrieve_body' )
+            ->once()
+            ->with( \Mockery::type( 'array' ) )
+            ->andReturn( '[]' );
+
+        $client = new Contifico_WooCommerce_Api_Contifico_Client();
+        $result = $client->update_stock(
+            'PROD123',
+            array(
+                'cantidad'     => '5.5',
+                'descripcion'  => 'Ajuste manual',
+            )
+        );
+
+        $this->assertIsArray( $result );
+        $this->assertNotNull( $captured_args );
+
+        $payload = json_decode( $captured_args['body'], true );
+
+        $this->assertIsArray( $payload );
+        $this->assertSame( 'AJU', $payload['tipo'] );
+        $this->assertSame( $expected_date, $payload['fecha'] );
+        $this->assertSame( 'bodega-001', $payload['bodega_id'] );
+        $this->assertSame( 'Ajuste manual', $payload['descripcion'] );
+        $this->assertArrayNotHasKey( 'cantidad', $payload );
+        $this->assertArrayHasKey( 'detalles', $payload );
+        $this->assertCount( 1, $payload['detalles'] );
+        $this->assertSame( 'PROD123', $payload['detalles'][0]['producto_id'] );
+        $this->assertSame( '5.5', $payload['detalles'][0]['cantidad'] );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Bootstrap para ejecutar las pruebas unitarias.
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/stubs/class-wp-error.php';
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+    function is_wp_error( $thing ) {
+        return $thing instanceof WP_Error;
+    }
+}
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text ) {
+        return $text;
+    }
+}
+
+if ( ! defined( 'CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY' ) ) {
+    define( 'CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY', true );
+}
+
+require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php';

--- a/tests/stubs/class-wp-error.php
+++ b/tests/stubs/class-wp-error.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Implementación mínima de WP_Error para ejecutar pruebas sin WordPress.
+ */
+class WP_Error {
+    /**
+     * Lista de errores agrupados por código.
+     *
+     * @var array
+     */
+    public $errors = array();
+
+    /**
+     * Datos adicionales asociados a cada error.
+     *
+     * @var array
+     */
+    public $error_data = array();
+
+    /**
+     * Constructor.
+     *
+     * @param string $code    Código del error.
+     * @param string $message Mensaje descriptivo.
+     * @param mixed  $data    Datos adicionales opcionales.
+     */
+    public function __construct( $code = '', $message = '', $data = '' ) {
+        if ( empty( $code ) ) {
+            return;
+        }
+
+        $this->errors[ $code ] = array();
+
+        if ( '' !== $message ) {
+            $this->errors[ $code ][] = $message;
+        }
+
+        if ( '' !== $data && null !== $data ) {
+            $this->error_data[ $code ] = $data;
+        }
+    }
+
+    /**
+     * Añade un error adicional al objeto.
+     *
+     * @param string $code    Código del error.
+     * @param string $message Mensaje a registrar.
+     * @param mixed  $data    Datos adicionales opcionales.
+     */
+    public function add( $code, $message, $data = '' ) {
+        if ( ! isset( $this->errors[ $code ] ) ) {
+            $this->errors[ $code ] = array();
+        }
+
+        $this->errors[ $code ][] = $message;
+
+        if ( '' !== $data && null !== $data ) {
+            $this->error_data[ $code ] = $data;
+        }
+    }
+
+    /**
+     * Devuelve el primer código de error disponible.
+     *
+     * @return string
+     */
+    public function get_error_code() {
+        $codes = array_keys( $this->errors );
+
+        return isset( $codes[0] ) ? $codes[0] : '';
+    }
+
+    /**
+     * Obtiene todos los mensajes registrados.
+     *
+     * @param string $code Código específico (opcional).
+     *
+     * @return array
+     */
+    public function get_error_messages( $code = '' ) {
+        if ( '' !== $code ) {
+            return isset( $this->errors[ $code ] ) ? $this->errors[ $code ] : array();
+        }
+
+        $all = array();
+        foreach ( $this->errors as $messages ) {
+            $all = array_merge( $all, $messages );
+        }
+
+        return $all;
+    }
+
+    /**
+     * Devuelve el primer mensaje disponible.
+     *
+     * @param string $code Código específico (opcional).
+     *
+     * @return string
+     */
+    public function get_error_message( $code = '' ) {
+        $messages = $this->get_error_messages( $code );
+
+        return isset( $messages[0] ) ? $messages[0] : '';
+    }
+
+    /**
+     * Recupera los datos asociados a un error.
+     *
+     * @param string $code Código del error.
+     *
+     * @return mixed
+     */
+    public function get_error_data( $code = '' ) {
+        if ( '' === $code ) {
+            $code = $this->get_error_code();
+        }
+
+        return isset( $this->error_data[ $code ] ) ? $this->error_data[ $code ] : null;
+    }
+
+    /**
+     * Indica si existen errores registrados.
+     *
+     * @return bool
+     */
+    public function has_errors() {
+        return ! empty( $this->errors );
+    }
+}

--- a/wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php
@@ -1,0 +1,800 @@
+<?php
+/**
+ * Cliente HTTP para la API de Contifico.
+ *
+ * @package Contifico_WooCommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Encapsula las solicitudes a la API de Contifico y maneja la autenticación.
+ */
+class Contifico_WooCommerce_Api_Contifico_Client {
+
+    /**
+     * Nombre del option donde se guardan los ajustes.
+     */
+    const OPTION_NAME = 'contifico_woocommerce_settings';
+
+    /**
+     * Origen utilizado para los mensajes del logger.
+     */
+    const LOG_SOURCE = 'contifico-woocommerce';
+
+    /**
+     * Timeout por defecto para las peticiones.
+     */
+    const DEFAULT_TIMEOUT = 20;
+
+    /**
+     * Número de reintentos cuando la API responde con códigos recuperables.
+     */
+    const DEFAULT_RETRIES = 2;
+
+    /**
+     * URL base oficial de la API de Contifico.
+     */
+    const DEFAULT_BASE_URL = 'https://api.contifico.com/sistema/api/v1';
+
+    /**
+     * Instancia del logger utilizada para registrar eventos.
+     *
+     * @var WC_Logger|null
+     */
+    protected $logger;
+
+    /**
+     * Ajustes almacenados de la integración.
+     *
+     * @var array|null
+     */
+    protected $settings;
+
+    /**
+     * Constructor.
+     *
+     * @param WC_Logger|null $logger   Logger personalizado.
+     * @param array|null     $settings Ajustes inyectados (principalmente para pruebas).
+     */
+    public function __construct( $logger = null, ?array $settings = null ) {
+        $this->logger   = $logger;
+        $this->settings = null !== $settings ? $this->prepare_settings( $settings ) : null;
+    }
+
+    /**
+     * Obtiene el listado de productos desde Contifico.
+     *
+     * @param array $params Parámetros opcionales de búsqueda.
+     *
+     * @return array|WP_Error
+     */
+    public function get_items( array $params = array() ) {
+        return $this->request(
+            'GET',
+            '/producto/',
+            array(
+                'query' => $params,
+            )
+        );
+    }
+
+    /**
+     * Obtiene la lista de bodegas disponibles en Contifico.
+     *
+     * @param array $params Parámetros opcionales de búsqueda.
+     *
+     * @return array|WP_Error
+     */
+    public function get_warehouses( array $params = array() ) {
+        return $this->request(
+            'GET',
+            '/bodega/',
+            array(
+                'query' => $params,
+            )
+        );
+    }
+
+    /**
+     * Registra una factura en Contifico.
+     *
+     * @param array $invoice Datos de la factura a crear.
+     *
+     * @return array|WP_Error
+     */
+    public function create_invoice( array $invoice ) {
+        return $this->request(
+            'POST',
+            '/documento/',
+            array(
+                'body' => $invoice,
+            )
+        );
+    }
+
+    /**
+     * Actualiza el stock de un producto en Contifico.
+     *
+     * @param string $item_id Identificador del producto en Contifico.
+     * @param array  $payload Datos de inventario a sincronizar.
+     *
+     * @return array|WP_Error
+     */
+    public function update_stock( $item_id, array $payload ) {
+        if ( empty( $item_id ) ) {
+            return $this->create_wp_error(
+                'contifico_missing_item_id',
+                $this->translate( 'Se requiere un identificador de producto para actualizar el stock.' )
+            );
+        }
+
+        $item_id  = (string) $item_id;
+        $movement = $payload;
+
+        if ( empty( $movement['tipo'] ) ) {
+            $movement['tipo'] = 'AJU';
+        }
+
+        if ( empty( $movement['fecha'] ) ) {
+            $movement['fecha'] = function_exists( 'gmdate' ) ? gmdate( 'd/m/Y' ) : date( 'd/m/Y' );
+        }
+
+        if ( isset( $movement['detalles'] ) ) {
+            if ( ! is_array( $movement['detalles'] ) || empty( $movement['detalles'] ) ) {
+                return $this->create_wp_error(
+                    'contifico_invalid_stock_details',
+                    $this->translate( 'Debes proporcionar al menos un detalle de producto para registrar el movimiento.' )
+                );
+            }
+
+            $normalized_details = array();
+            $has_item_detail    = false;
+
+            foreach ( $movement['detalles'] as $detail ) {
+                if ( ! is_array( $detail ) ) {
+                    return $this->create_wp_error(
+                        'contifico_invalid_stock_details',
+                        $this->translate( 'Cada detalle de inventario debe ser un arreglo asociativo.' )
+                    );
+                }
+
+                if ( empty( $detail['producto_id'] ) ) {
+                    $detail['producto_id'] = $item_id;
+                }
+
+                if ( isset( $movement['cantidad'] ) && ! isset( $detail['cantidad'] ) ) {
+                    $detail['cantidad'] = $movement['cantidad'];
+                }
+
+                if ( isset( $movement['precio'] ) && ! isset( $detail['precio'] ) ) {
+                    $detail['precio'] = $movement['precio'];
+                }
+
+                if ( (string) $detail['producto_id'] === $item_id ) {
+                    $has_item_detail = true;
+                }
+
+                $normalized_details[] = $detail;
+            }
+
+            if ( ! $has_item_detail ) {
+                $fallback_detail = array(
+                    'producto_id' => $item_id,
+                );
+
+                if ( isset( $movement['cantidad'] ) ) {
+                    $fallback_detail['cantidad'] = $movement['cantidad'];
+                }
+
+                if ( isset( $movement['precio'] ) ) {
+                    $fallback_detail['precio'] = $movement['precio'];
+                }
+
+                $normalized_details[] = $fallback_detail;
+            }
+
+            $movement['detalles'] = array_values( array_filter(
+                $normalized_details,
+                function ( $detail ) {
+                    return is_array( $detail ) && ! empty( $detail['producto_id'] );
+                }
+            ) );
+        } else {
+            $detail = array(
+                'producto_id' => $item_id,
+            );
+
+            if ( isset( $movement['cantidad'] ) ) {
+                $detail['cantidad'] = $movement['cantidad'];
+            }
+
+            if ( isset( $movement['precio'] ) ) {
+                $detail['precio'] = $movement['precio'];
+            }
+
+            $movement['detalles'] = array( $detail );
+        }
+
+        unset( $movement['cantidad'], $movement['precio'] );
+
+        if ( empty( $movement['detalles'] ) ) {
+            return $this->create_wp_error(
+                'contifico_invalid_stock_details',
+                $this->translate( 'No fue posible construir los detalles del movimiento de inventario.' )
+            );
+        }
+
+        if ( empty( $movement['bodega_id'] ) ) {
+            $settings = $this->get_settings();
+            if ( ! empty( $settings['warehouse'] ) ) {
+                $movement['bodega_id'] = $settings['warehouse'];
+            }
+        }
+
+        return $this->request(
+            'POST',
+            '/movimiento-inventario/',
+            array(
+                'body' => $movement,
+            )
+        );
+    }
+
+    /**
+     * Realiza la solicitud HTTP principal contra la API de Contifico.
+     *
+     * @param string $method   Método HTTP (GET, POST, PUT, ...).
+     * @param string $endpoint Ruta relativa del recurso.
+     * @param array  $options  Opciones adicionales de la petición.
+     *
+     * @return array|WP_Error
+     */
+    protected function request( $method, $endpoint, array $options = array() ) {
+        $options = array_merge(
+            array(
+                'body'    => null,
+                'headers' => array(),
+                'query'   => array(),
+                'timeout' => self::DEFAULT_TIMEOUT,
+                'retries' => self::DEFAULT_RETRIES,
+            ),
+            $options
+        );
+
+        $method = strtoupper( $method );
+
+        $base_url = $this->get_base_url();
+        if ( $this->is_error( $base_url ) ) {
+            return $base_url;
+        }
+
+        $token = $this->get_auth_token();
+        if ( $this->is_error( $token ) ) {
+            return $token;
+        }
+
+        $url = $this->build_url( $base_url, $endpoint, $options['query'] );
+
+        $headers = array_merge(
+            $this->get_default_headers( $token ),
+            $options['headers']
+        );
+
+        $request_args = array(
+            'method'  => $method,
+            'headers' => $headers,
+            'timeout' => max( 1, (int) $options['timeout'] ),
+        );
+
+        if ( null !== $options['body'] ) {
+            $prepared_body = $this->prepare_body( $options['body'] );
+            if ( $this->is_error( $prepared_body ) ) {
+                return $prepared_body;
+            }
+
+            $request_args['body'] = $prepared_body;
+
+            if ( ! isset( $request_args['headers']['Content-Type'] ) ) {
+                $request_args['headers']['Content-Type'] = 'application/json';
+            }
+        }
+
+        $attempt     = 0;
+        $max_attempts = max( 1, (int) $options['retries'] + 1 );
+        $last_error  = null;
+
+        do {
+            $attempt++;
+
+            $response = wp_remote_request( $url, $request_args );
+
+            if ( $this->is_error( $response ) ) {
+                $last_error = $this->handle_transport_error( $response, $endpoint, $attempt );
+
+                if ( $attempt >= $max_attempts ) {
+                    return $last_error;
+                }
+
+                $this->wait_before_retry( $attempt );
+                continue;
+            }
+
+            $status_code = (int) wp_remote_retrieve_response_code( $response );
+
+            if ( $status_code >= 200 && $status_code < 300 ) {
+                return $this->handle_success_response( $response );
+            }
+
+            if ( $this->should_retry_status( $status_code ) && $attempt < $max_attempts ) {
+                $this->log(
+                    'warning',
+                    sprintf( 'Reintentando solicitud debido a código HTTP %d.', $status_code ),
+                    array(
+                        'endpoint' => $endpoint,
+                        'attempt'  => $attempt,
+                    )
+                );
+
+                $this->wait_before_retry( $attempt );
+                continue;
+            }
+
+            return $this->handle_http_error( $response, $status_code, $endpoint );
+        } while ( $attempt < $max_attempts );
+
+        return $last_error ? $last_error : $this->create_wp_error(
+            'contifico_http_request_error',
+            $this->translate( 'No se pudo comunicar con el servicio de Contifico.' )
+        );
+    }
+
+    /**
+     * Prepara el cuerpo de la petición asegurando que sea JSON válido.
+     *
+     * @param mixed $body Datos a codificar.
+     *
+     * @return string|WP_Error
+     */
+    protected function prepare_body( $body ) {
+        if ( is_array( $body ) || is_object( $body ) ) {
+            $encoded = $this->json_encode( $body );
+
+            if ( false === $encoded ) {
+                return $this->create_wp_error(
+                    'contifico_json_encoding_error',
+                    $this->translate( 'No fue posible preparar el cuerpo de la solicitud para Contifico.' )
+                );
+            }
+
+            return $encoded;
+        }
+
+        if ( is_string( $body ) ) {
+            return $body;
+        }
+
+        return $this->create_wp_error(
+            'contifico_invalid_body',
+            $this->translate( 'El formato del cuerpo de la solicitud no es válido.' )
+        );
+    }
+
+    /**
+     * Devuelve la URL base configurada para la API.
+     *
+     * @return string|WP_Error
+     */
+    protected function get_base_url() {
+        $settings = $this->get_settings();
+        $api_url  = isset( $settings['api_url'] ) ? trim( $settings['api_url'] ) : '';
+
+        if ( '' === $api_url ) {
+            $api_url = self::DEFAULT_BASE_URL;
+        }
+
+        return rtrim( $api_url, '/' );
+    }
+
+    /**
+     * Obtiene el token de autenticación almacenado en los ajustes.
+     *
+     * @return string|WP_Error
+     */
+    protected function get_auth_token() {
+        $settings = $this->get_settings();
+        $api_key = isset( $settings['api_key'] ) ? trim( $settings['api_key'] ) : '';
+
+        if ( '' === $api_key ) {
+            return $this->create_wp_error(
+                'contifico_missing_token',
+                $this->translate( 'Configura el API Key de Contifico antes de realizar solicitudes.' )
+            );
+        }
+
+        return $api_key;
+    }
+
+    /**
+     * Construye la URL completa para la petición.
+     *
+     * @param string $base_url Base de la API.
+     * @param string $endpoint Ruta del recurso.
+     * @param array  $query    Parámetros de consulta.
+     *
+     * @return string
+     */
+    protected function build_url( $base_url, $endpoint, array $query = array() ) {
+        $base_url = rtrim( $base_url, '/' );
+        $endpoint = '/' . ltrim( $endpoint, '/' );
+        $url      = $base_url . $endpoint;
+
+        if ( ! empty( $query ) ) {
+            $url .= '?' . http_build_query( $query, '', '&' );
+        }
+
+        return $url;
+    }
+
+    /**
+     * Maneja la respuesta exitosa de la API.
+     *
+     * @param array $response Respuesta HTTP.
+     *
+     * @return array|WP_Error
+     */
+    protected function handle_success_response( $response ) {
+        $body = wp_remote_retrieve_body( $response );
+
+        if ( '' === trim( (string) $body ) ) {
+            return array();
+        }
+
+        $decoded = json_decode( $body, true );
+
+        if ( null === $decoded && JSON_ERROR_NONE !== json_last_error() ) {
+            $this->log(
+                'error',
+                'No se pudo decodificar la respuesta de Contifico.',
+                array( 'body' => $body )
+            );
+
+            return $this->create_wp_error(
+                'contifico_invalid_response',
+                $this->translate( 'Contifico devolvió una respuesta inválida.' ),
+                array( 'body' => $body )
+            );
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Genera un WP_Error a partir de una respuesta HTTP con error.
+     *
+     * @param array  $response    Respuesta HTTP completa.
+     * @param int    $status_code Código de estado recibido.
+     * @param string $endpoint    Endpoint solicitado.
+     *
+     * @return WP_Error
+     */
+    protected function handle_http_error( $response, $status_code, $endpoint ) {
+        $body    = wp_remote_retrieve_body( $response );
+        $message = $this->parse_error_message( $body );
+
+        if ( '' === $message ) {
+            $message = sprintf(
+                $this->translate( 'La API de Contifico devolvió el código de estado %d.' ),
+                $status_code
+            );
+        }
+
+        $this->log(
+            'error',
+            'Error HTTP recibido desde Contifico.',
+            array(
+                'endpoint' => $endpoint,
+                'status'   => $status_code,
+                'body'     => $body,
+            )
+        );
+
+        return $this->create_wp_error(
+            'contifico_http_error',
+            $message,
+            array(
+                'status' => $status_code,
+                'body'   => $body,
+            )
+        );
+    }
+
+    /**
+     * Maneja los errores de transporte devueltos por wp_remote_request.
+     *
+     * @param WP_Error $error    Error original.
+     * @param string   $endpoint Endpoint solicitado.
+     * @param int      $attempt  Número de intento realizado.
+     *
+     * @return WP_Error
+     */
+    protected function handle_transport_error( $error, $endpoint, $attempt ) {
+        $message = $error->get_error_message();
+
+        $this->log(
+            'error',
+            'Error de transporte al contactar con Contifico.',
+            array(
+                'endpoint' => $endpoint,
+                'attempt'  => $attempt,
+                'message'  => $message,
+            )
+        );
+
+        return $this->create_wp_error(
+            'contifico_http_request_error',
+            $this->translate( 'No se pudo comunicar con el servicio de Contifico.' ),
+            array(
+                'previous' => $error,
+            )
+        );
+    }
+
+    /**
+     * Determina si una respuesta HTTP amerita reintentar la solicitud.
+     *
+     * @param int $status_code Código de estado HTTP.
+     *
+     * @return bool
+     */
+    protected function should_retry_status( $status_code ) {
+        $retryable = array( 408, 425, 429, 500, 502, 503, 504 );
+
+        return in_array( (int) $status_code, $retryable, true );
+    }
+
+    /**
+     * Espera un tiempo antes de repetir una solicitud.
+     *
+     * @param int $attempt Número de intento actual.
+     *
+     * @return void
+     */
+    protected function wait_before_retry( $attempt ) {
+        if ( defined( 'CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY' ) && CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY ) {
+            return;
+        }
+
+        $delay = min( 3, $attempt ) * 0.25; // Incremento leve para evitar bloqueos.
+
+        if ( function_exists( 'wp_sleep' ) ) {
+            wp_sleep( (int) ceil( $delay ) );
+            return;
+        }
+
+        usleep( (int) ( $delay * 1000000 ) );
+    }
+
+    /**
+     * Registra mensajes en el logger configurado.
+     *
+     * @param string $level   Nivel del mensaje.
+     * @param string $message Contenido del mensaje.
+     * @param array  $context Datos adicionales.
+     *
+     * @return void
+     */
+    protected function log( $level, $message, array $context = array() ) {
+        $logger = $this->get_logger();
+
+        if ( $logger ) {
+            $logger->log(
+                $level,
+                $message,
+                array_merge(
+                    array( 'source' => self::LOG_SOURCE ),
+                    $context
+                )
+            );
+            return;
+        }
+
+        $context_output = '';
+
+        if ( ! empty( $context ) ) {
+            $encoded = $this->json_encode( $context );
+            if ( false !== $encoded ) {
+                $context_output = ' ' . $encoded;
+            }
+        }
+
+        error_log( sprintf( '[%s] %s%s', strtoupper( $level ), $message, $context_output ) );
+    }
+
+    /**
+     * Obtiene el logger disponible en WooCommerce.
+     *
+     * @return WC_Logger|null
+     */
+    protected function get_logger() {
+        if ( null !== $this->logger ) {
+            return $this->logger;
+        }
+
+        if ( function_exists( 'wc_get_logger' ) ) {
+            $this->logger = wc_get_logger();
+        }
+
+        return $this->logger;
+    }
+
+    /**
+     * Determina si el valor entregado es un WP_Error.
+     *
+     * @param mixed $value Valor a evaluar.
+     *
+     * @return bool
+     */
+    protected function is_error( $value ) {
+        return ( is_object( $value ) && $value instanceof WP_Error );
+    }
+
+    /**
+     * Devuelve los ajustes guardados, en cache si ya se solicitaron anteriormente.
+     *
+     * @return array
+     */
+    protected function get_settings() {
+        if ( null !== $this->settings ) {
+            return $this->settings;
+        }
+
+        $stored = array();
+
+        if ( function_exists( 'get_option' ) ) {
+            $stored = get_option( self::OPTION_NAME, array() );
+        }
+
+        if ( ! is_array( $stored ) ) {
+            $stored = array();
+        }
+
+        $this->settings = $this->prepare_settings( $stored );
+
+        return $this->settings;
+    }
+
+    /**
+     * Asegura que los ajustes contengan las claves esperadas.
+     *
+     * @param array $settings Ajustes originales.
+     *
+     * @return array
+     */
+    protected function prepare_settings( array $settings ) {
+        $defaults = array(
+            'api_url'    => '',
+            'api_key'    => '',
+            'api_secret' => '',
+            'warehouse'  => '',
+        );
+
+        return array_merge( $defaults, $settings );
+    }
+
+    /**
+     * Crea un objeto WP_Error consistente.
+     *
+     * @param string $code    Código del error.
+     * @param string $message Mensaje descriptivo.
+     * @param array  $data    Datos adicionales.
+     *
+     * @return WP_Error
+     */
+    protected function create_wp_error( $code, $message, array $data = array() ) {
+        return new WP_Error( $code, $message, $data );
+    }
+
+    /**
+     * Obtiene los encabezados mínimos que deben incluirse en la petición.
+     *
+     * @param string $token Token de autenticación.
+     *
+     * @return array
+     */
+    protected function get_default_headers( $token ) {
+        $headers = array(
+            'Accept' => 'application/json',
+        );
+
+        if ( '' !== trim( (string) $token ) ) {
+            $headers['Authorization'] = $token;
+        }
+
+        $headers['User-Agent'] = 'Contifico WooCommerce/' . ( defined( 'CONTIFICO_WOOCOMMERCE_VERSION' ) ? CONTIFICO_WOOCOMMERCE_VERSION : '1.0.0' );
+
+        return $headers;
+    }
+
+    /**
+     * Extrae un mensaje de error de una respuesta JSON de la API.
+     *
+     * @param string $body Cuerpo recibido.
+     *
+     * @return string
+     */
+    protected function parse_error_message( $body ) {
+        $body = (string) $body;
+
+        if ( '' === trim( $body ) ) {
+            return '';
+        }
+
+        $decoded = json_decode( $body, true );
+
+        if ( null === $decoded || JSON_ERROR_NONE !== json_last_error() ) {
+            return '';
+        }
+
+        if ( isset( $decoded['message'] ) && is_string( $decoded['message'] ) ) {
+            return $decoded['message'];
+        }
+
+        if ( isset( $decoded['error'] ) && is_string( $decoded['error'] ) ) {
+            return $decoded['error'];
+        }
+
+        if ( isset( $decoded['errors'] ) ) {
+            if ( is_array( $decoded['errors'] ) ) {
+                $messages = array();
+                foreach ( $decoded['errors'] as $error ) {
+                    if ( is_string( $error ) ) {
+                        $messages[] = $error;
+                    } elseif ( is_array( $error ) ) {
+                        $messages = array_merge( $messages, array_filter( $error, 'is_string' ) );
+                    }
+                }
+
+                return implode( ' ', array_filter( $messages ) );
+            }
+
+            if ( is_string( $decoded['errors'] ) ) {
+                return $decoded['errors'];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Codifica datos a JSON utilizando las utilidades de WordPress si están disponibles.
+     *
+     * @param mixed $data Datos a codificar.
+     *
+     * @return string|false
+     */
+    protected function json_encode( $data ) {
+        if ( function_exists( 'wp_json_encode' ) ) {
+            return wp_json_encode( $data );
+        }
+
+        return json_encode( $data );
+    }
+
+    /**
+     * Traduce un texto si la función de internacionalización está disponible.
+     *
+     * @param string $text Texto original.
+     *
+     * @return string
+     */
+    protected function translate( $text ) {
+        if ( function_exists( '__' ) ) {
+            return __( $text, 'contifico-woocommerce' );
+        }
+
+        return $text;
+    }
+}

--- a/wp-content/plugins/contifico-woocommerce/includes/class-autoloader.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/class-autoloader.php
@@ -80,6 +80,10 @@ class Contifico_WooCommerce_Autoloader {
                 $directory = 'public';
                 $parts     = array_slice( $parts, 1 );
                 $parts     = ! empty( $parts ) ? $parts : array( 'public' );
+            } elseif ( 'api' === $parts[0] ) {
+                $directory = 'includes/api';
+                $parts     = array_slice( $parts, 1 );
+                $parts     = ! empty( $parts ) ? $parts : array( 'api' );
             }
         }
 


### PR DESCRIPTION
## Summary
- switch the Contifico client helpers to the documented `/producto/`, `/bodega/`, `/documento/` and `/movimiento-inventario/` endpoints while defaulting to the official base URL and API key header
- rebuild `update_stock` so it creates an `AJU` inventory movement, fills in product details, and falls back to the configured warehouse when none is provided
- refresh the README and Brain Monkey tests to cover the official endpoints and the new stock adjustment behaviour

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d17d7e44d083328b5234d3158ec039