### PR TITLE
Replace binary release artifact with reproducible build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /.phpunit.result.cache
+dist/*.zip

--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ composer test
 ```
 
 Las pruebas se encuentran en el directorio `tests/` e incluyen dobles de WordPress para `WP_Error` y funciones comunes.
+
+## Distribución
+
+Para crear un paquete instalable del plugin, asegúrate de tener habilitada la extensión `zip` de PHP y ejecuta:
+
+```bash
+composer build-release
+```
+
+Esto generará `dist/contifico-woocommerce.zip`, que puede cargarse directamente desde el administrador de WordPress en **Plugins → Añadir nuevo → Subir plugin**.

--- a/bin/build-release.php
+++ b/bin/build-release.php
@@ -1,0 +1,91 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$pluginSlug = 'contifico-woocommerce';
+$projectRoot = dirname(__DIR__);
+$pluginDir = $projectRoot . '/wp-content/plugins/' . $pluginSlug;
+$distDir = $projectRoot . '/dist';
+$outputFile = $distDir . '/' . $pluginSlug . '.zip';
+$excludedPatterns = [
+    '#(^|/)\.git(/|$)#',
+    '#(^|/)\.github(/|$)#',
+    '#(^|/)node_modules(/|$)#',
+    '#(^|/)vendor(/|$)#',
+    '#(^|/)\.DS_Store$#',
+];
+
+if (!class_exists(ZipArchive::class)) {
+    fwrite(STDERR, "La extensión de PHP 'zip' es requerida para generar el paquete.\n");
+    exit(1);
+}
+
+if (!is_dir($pluginDir)) {
+    fwrite(STDERR, "No se encontró el directorio del plugin en {$pluginDir}.\n");
+    exit(1);
+}
+
+if (!is_dir($distDir) && !mkdir($distDir, 0775, true) && !is_dir($distDir)) {
+    fwrite(STDERR, "No fue posible crear el directorio dist en {$distDir}.\n");
+    exit(1);
+}
+
+if (file_exists($outputFile) && !unlink($outputFile)) {
+    fwrite(STDERR, "No fue posible eliminar el paquete existente en {$outputFile}.\n");
+    exit(1);
+}
+
+$zip = new ZipArchive();
+if ($zip->open($outputFile, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    fwrite(STDERR, "No se pudo crear el archivo ZIP en {$outputFile}.\n");
+    exit(1);
+}
+
+$zip->addEmptyDir($pluginSlug);
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($pluginDir, RecursiveDirectoryIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::SELF_FIRST
+);
+
+/** @var \SplFileInfo $file */
+foreach ($iterator as $file) {
+    $filePath = $file->getPathname();
+    $relativePath = substr($filePath, strlen($pluginDir) + 1);
+
+    if ($relativePath === false || $relativePath === '') {
+        continue;
+    }
+
+    $normalizedPath = str_replace('\\', '/', $relativePath);
+
+    foreach ($excludedPatterns as $pattern) {
+        if (preg_match($pattern, $normalizedPath) === 1) {
+            if ($file->isDir()) {
+                $iterator->skipChildren();
+            }
+            continue 2;
+        }
+    }
+
+    $destinationPath = $pluginSlug . '/' . $normalizedPath;
+
+    if ($file->isDir()) {
+        $zip->addEmptyDir($destinationPath);
+        continue;
+    }
+
+    if (!$zip->addFile($filePath, $destinationPath)) {
+        fwrite(STDERR, "No se pudo agregar {$filePath} al paquete ZIP.\n");
+        $zip->close();
+        exit(1);
+    }
+}
+
+if (!$zip->close()) {
+    fwrite(STDERR, "Error al cerrar el archivo ZIP {$outputFile}.\n");
+    exit(1);
+}
+
+echo "Paquete generado en {$outputFile}\n";

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "build-release": "php bin/build-release.php"
     },
     "minimum-stability": "stable",
     "prefer-stable": true

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,9 @@
+# Paquetes de distribución
+
+Ejecuta el siguiente comando para generar un paquete instalable del plugin:
+
+```bash
+composer build-release
+```
+
+El script creará `contifico-woocommerce.zip` en este mismo directorio, listo para subirlo como plugin a un sitio de WordPress.


### PR DESCRIPTION
## Summary
- replace the committed ZIP with a PHP build script that packages the plugin for WordPress
- expose the script through a Composer command and document how to build the installable ZIP
- ignore generated ZIP artifacts so release builds no longer block pull requests

## Testing
- composer build-release
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d19412b4f483329d9c2d612d334c61