### PR TITLE
Clean up stale inventory metadata and cover variations

### DIFF
--- a/tests/InventorySyncTest.php
+++ b/tests/InventorySyncTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class Testable_Contifico_WooCommerce_Sync_Inventory_Sync extends Contifico_WooCommerce_Sync_Inventory_Sync {
+
+    public function call_resolve_product_id( array $item ) {
+        return $this->resolve_product_id( $item );
+    }
+
+    public function call_process_inventory_response( array $warehouses ) {
+        return $this->process_inventory_response( $warehouses );
+    }
+}
+
+class InventorySyncTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        \Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_resolve_product_id_accepts_variations() {
+        Functions\expect( 'get_post_type' )
+            ->once()
+            ->with( 321 )
+            ->andReturn( 'product_variation' );
+
+        $sync   = new Testable_Contifico_WooCommerce_Sync_Inventory_Sync();
+        $result = $sync->call_resolve_product_id( array( 'woocommerce_id' => '321' ) );
+
+        $this->assertSame( 321, $result );
+    }
+
+    public function test_process_inventory_response_cleans_stale_metadata() {
+        Functions\expect( 'get_posts' )
+            ->once()
+            ->andReturn( array( 10, 20 ) );
+
+        Functions\expect( 'get_post_type' )
+            ->once()
+            ->with( 10 )
+            ->andReturn( 'product' );
+
+        Functions\when( 'wc_stock_amount' )
+            ->alias( function ( $value ) {
+                return $value;
+            } );
+
+        $timestamp = '2024-01-01 00:00:00';
+
+        Functions\expect( 'current_time' )
+            ->once()
+            ->with( 'mysql', true )
+            ->andReturn( $timestamp );
+
+        Functions\expect( 'update_post_meta' )
+            ->once()
+            ->with(
+                10,
+                Contifico_WooCommerce_Sync_Inventory_Sync::META_KEY,
+                \Mockery::on(
+                    function ( $value ) use ( $timestamp ) {
+                        return isset( $value['main'] )
+                            && 'main' === $value['main']['warehouse_id']
+                            && abs( 8 - (float) $value['main']['stock'] ) < 0.0001
+                            && $timestamp === $value['main']['updated_at_gmt'];
+                    }
+                )
+            );
+
+        Functions\expect( 'delete_post_meta' )
+            ->once()
+            ->with( 20, Contifico_WooCommerce_Sync_Inventory_Sync::META_KEY );
+
+        $sync    = new Testable_Contifico_WooCommerce_Sync_Inventory_Sync();
+        $summary = $sync->call_process_inventory_response(
+            array(
+                array(
+                    'id'    => 'main',
+                    'nombre' => 'Principal',
+                    'items'  => array(
+                        array(
+                            'woocommerce_id' => 10,
+                            'stock'          => 8,
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        $this->assertSame( 1, $summary['warehouses'] );
+        $this->assertSame( 1, $summary['items_processed'] );
+        $this->assertSame( 1, $summary['products_updated'] );
+        $this->assertSame( 1, $summary['products_cleaned'] );
+        $this->assertSame( array(), $summary['errors'] );
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,8 +23,21 @@ if ( ! function_exists( '__' ) ) {
     }
 }
 
+if ( ! function_exists( 'esc_html__' ) ) {
+    function esc_html__( $text ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+    function esc_html( $text ) {
+        return $text;
+    }
+}
+
 if ( ! defined( 'CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY' ) ) {
     define( 'CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY', true );
 }
 
 require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php';
+require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php';

--- a/wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php
@@ -275,11 +275,12 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
      * @return array
      */
     protected function process_inventory_response( array $warehouses ) {
-        $grouped_inventory = array();
-        $updated_products  = array();
-        $errors            = array();
-        $warehouses_count  = 0;
-        $items_processed   = 0;
+        $existing_inventory = $this->get_products_with_inventory_meta();
+        $grouped_inventory  = array();
+        $updated_products   = array();
+        $errors             = array();
+        $warehouses_count   = 0;
+        $items_processed    = 0;
 
         foreach ( $warehouses as $warehouse ) {
             $warehouse_id = $this->get_warehouse_id( $warehouse );
@@ -354,6 +355,25 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
             }
         }
 
+        $products_in_response = array_map( 'absint', array_keys( $grouped_inventory ) );
+        $products_in_response = array_values( array_filter( array_unique( $products_in_response ) ) );
+
+        $stale_products  = array_diff( $existing_inventory, $products_in_response );
+        $products_cleaned = 0;
+
+        if ( ! empty( $stale_products ) ) {
+            foreach ( $stale_products as $product_id ) {
+                $product_id = absint( $product_id );
+
+                if ( ! $product_id ) {
+                    continue;
+                }
+
+                delete_post_meta( $product_id, self::META_KEY );
+                $products_cleaned++;
+            }
+        }
+
         foreach ( $grouped_inventory as $product_id => $warehouses_stock ) {
             if ( empty( $warehouses_stock ) ) {
                 delete_post_meta( $product_id, self::META_KEY );
@@ -367,8 +387,40 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
             'warehouses'       => $warehouses_count,
             'products_updated' => count( $updated_products ),
             'items_processed'  => $items_processed,
+            'products_cleaned' => $products_cleaned,
             'errors'           => $errors,
         );
+    }
+
+    /**
+     * Obtiene el listado de productos que actualmente almacenan el meta de inventario.
+     *
+     * @return array
+     */
+    protected function get_products_with_inventory_meta() {
+        if ( ! function_exists( 'get_posts' ) ) {
+            return array();
+        }
+
+        $posts = get_posts(
+            array(
+                'post_type'      => array( 'product', 'product_variation' ),
+                'meta_key'       => self::META_KEY,
+                'fields'         => 'ids',
+                'posts_per_page' => -1,
+                'post_status'    => 'any',
+                'no_found_rows'  => true,
+                'suppress_filters' => true,
+            )
+        );
+
+        if ( ! is_array( $posts ) ) {
+            return array();
+        }
+
+        $posts = array_map( 'absint', $posts );
+
+        return array_values( array_filter( array_unique( $posts ) ) );
     }
 
     /**
@@ -448,7 +500,9 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
             if ( isset( $item[ $key ] ) && '' !== $item[ $key ] ) {
                 $candidate = absint( $item[ $key ] );
 
-                if ( $candidate && 'product' === get_post_type( $candidate ) ) {
+                $post_type = $candidate ? get_post_type( $candidate ) : '';
+
+                if ( $candidate && in_array( $post_type, array( 'product', 'product_variation' ), true ) ) {
                     return $candidate;
                 }
             }


### PR DESCRIPTION
## Summary
- clean up stale Contifico inventory metadata that no longer appears in the latest sync response
- allow inventory sync to resolve product variation IDs and report how many products were cleaned
- extend the unit test bootstrap and add coverage for the new inventory behaviours

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d33a7a22788332b2d890da3dd9c42d