### PR TITLE
Implement batch inventory sync with Action Scheduler

### DIFF
--- a/tests/InventorySyncTest.php
+++ b/tests/InventorySyncTest.php
@@ -1,0 +1,236 @@
+<?php
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class Testable_Contifico_WooCommerce_Sync_Inventory_Sync extends Contifico_WooCommerce_Sync_Inventory_Sync {
+
+    public function call_resolve_product_id( array $item ) {
+        return $this->resolve_product_id( $item );
+    }
+
+    public function call_process_inventory_response( array $warehouses, array $args = array() ) {
+        return $this->process_inventory_response( $warehouses, $args );
+    }
+
+    public function set_client( $client ) {
+        $this->client = $client;
+    }
+}
+
+class InventorySyncTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        \Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_resolve_product_id_accepts_variations() {
+        Functions\expect( 'get_post_type' )
+            ->once()
+            ->with( 321 )
+            ->andReturn( 'product_variation' );
+
+        $sync   = new Testable_Contifico_WooCommerce_Sync_Inventory_Sync();
+        $result = $sync->call_resolve_product_id( array( 'woocommerce_id' => '321' ) );
+
+        $this->assertSame( 321, $result );
+    }
+
+    public function test_process_inventory_response_cleans_stale_metadata() {
+        Functions\expect( 'get_posts' )
+            ->once()
+            ->andReturn( array( 10, 20 ) );
+
+        Functions\expect( 'get_post_type' )
+            ->once()
+            ->with( 10 )
+            ->andReturn( 'product' );
+
+        Functions\when( 'wc_stock_amount' )
+            ->alias( function ( $value ) {
+                return $value;
+            } );
+
+        $timestamp = '2024-01-01 00:00:00';
+
+        Functions\expect( 'current_time' )
+            ->once()
+            ->with( 'mysql', true )
+            ->andReturn( $timestamp );
+
+        Functions\expect( 'update_post_meta' )
+            ->once()
+            ->with(
+                10,
+                Contifico_WooCommerce_Sync_Inventory_Sync::META_KEY,
+                \Mockery::on(
+                    function ( $value ) use ( $timestamp ) {
+                        return isset( $value['main'] )
+                            && 'main' === $value['main']['warehouse_id']
+                            && abs( 8 - (float) $value['main']['stock'] ) < 0.0001
+                            && $timestamp === $value['main']['updated_at_gmt'];
+                    }
+                )
+            );
+
+        Functions\expect( 'delete_post_meta' )
+            ->once()
+            ->with( 20, Contifico_WooCommerce_Sync_Inventory_Sync::META_KEY );
+
+        $sync    = new Testable_Contifico_WooCommerce_Sync_Inventory_Sync();
+        $summary = $sync->call_process_inventory_response(
+            array(
+                array(
+                    'id'    => 'main',
+                    'nombre' => 'Principal',
+                    'items'  => array(
+                        array(
+                            'woocommerce_id' => 10,
+                            'stock'          => 8,
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        $this->assertSame( 1, $summary['warehouses'] );
+        $this->assertSame( 1, $summary['items_processed'] );
+        $this->assertSame( 1, $summary['products_updated'] );
+        $this->assertSame( 1, $summary['products_cleaned'] );
+        $this->assertSame( array(), $summary['errors'] );
+        $this->assertSame( array( 10 ), $summary['processed_product_ids'] );
+    }
+
+    public function test_process_inventory_response_skips_cleanup_when_disabled() {
+        Functions\expect( 'get_posts' )
+            ->never();
+
+        $timestamp = '2024-02-01 12:00:00';
+
+        Functions\expect( 'update_post_meta' )
+            ->once()
+            ->with(
+                10,
+                Contifico_WooCommerce_Sync_Inventory_Sync::META_KEY,
+                \Mockery::on(
+                    function ( $value ) use ( $timestamp ) {
+                        return isset( $value['main'] ) && $timestamp === $value['main']['updated_at_gmt'];
+                    }
+                )
+            );
+
+        Functions\expect( 'delete_post_meta' )
+            ->never();
+
+        Functions\expect( 'get_post_type' )
+            ->once()
+            ->with( 10 )
+            ->andReturn( 'product' );
+
+        Functions\when( 'wc_stock_amount' )
+            ->alias( function ( $value ) {
+                return $value;
+            } );
+
+        $sync    = new Testable_Contifico_WooCommerce_Sync_Inventory_Sync();
+        $summary = $sync->call_process_inventory_response(
+            array(
+                array(
+                    'id'   => 'main',
+                    'items' => array(
+                        array(
+                            'woocommerce_id' => 10,
+                            'stock'          => 5,
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                'clean_stale'        => false,
+                'existing_inventory' => array( 10 ),
+                'timestamp'          => $timestamp,
+            )
+        );
+
+        $this->assertSame( 0, $summary['products_cleaned'] );
+        $this->assertSame( array( 10 ), $summary['processed_product_ids'] );
+    }
+
+    public function test_start_batch_sync_initializes_state_and_schedules_action() {
+        Functions\expect( 'get_option' )
+            ->once()
+            ->with( Contifico_WooCommerce_Sync_Inventory_Sync::BATCH_STATE_OPTION, array() )
+            ->andReturn( array() );
+
+        Functions\when( 'apply_filters' )
+            ->alias( function ( $hook, $value ) {
+                return $value;
+            } );
+
+        Functions\expect( 'get_posts' )
+            ->once()
+            ->andReturn( array( 100 ) );
+
+        Functions\expect( 'current_time' )
+            ->once()
+            ->with( 'timestamp', true )
+            ->andReturn( 123456 );
+
+        Functions\expect( 'update_option' )
+            ->once()
+            ->with(
+                Contifico_WooCommerce_Sync_Inventory_Sync::BATCH_STATE_OPTION,
+                \Mockery::on(
+                    function ( $value ) {
+                        return isset( $value['warehouses']['main'] )
+                            && 'Principal' === $value['warehouses']['main']['name']
+                            && isset( $value['cleanup_candidates'][100] )
+                            && 1 === $value['current_step'];
+                    }
+                ),
+                false
+            );
+
+        Functions\expect( 'as_enqueue_async_action' )
+            ->once()
+            ->with(
+                Contifico_WooCommerce_Sync_Inventory_Sync::BATCH_ACTION,
+                array( array( 'step' => 1 ) ),
+                Contifico_WooCommerce_Sync_Inventory_Sync::ACTION_SCHEDULER_GROUP
+            );
+
+        Functions\expect( 'wc_get_logger' )
+            ->once()
+            ->andReturn( null );
+
+        $client = new class {
+            public function get_warehouses() {
+                return array(
+                    array(
+                        'id'     => 'main',
+                        'nombre' => 'Principal',
+                    ),
+                );
+            }
+        };
+
+        $sync = new Testable_Contifico_WooCommerce_Sync_Inventory_Sync();
+        $sync->set_client( $client );
+
+        $result = $sync->start_batch_sync( 'manual' );
+
+        $this->assertIsArray( $result );
+        $this->assertSame( 'queued', $result['summary']['status'] );
+        $this->assertSame( 1, $result['summary']['warehouses'] );
+        $this->assertSame( Contifico_WooCommerce_Sync_Inventory_Sync::DEFAULT_BATCH_SIZE, $result['summary']['batch_size'] );
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,8 +23,35 @@ if ( ! function_exists( '__' ) ) {
     }
 }
 
+if ( ! function_exists( 'esc_html__' ) ) {
+    function esc_html__( $text ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'wp_parse_args' ) ) {
+    function wp_parse_args( $args, $defaults = array() ) {
+        if ( is_object( $args ) ) {
+            $args = get_object_vars( $args );
+        }
+
+        if ( ! is_array( $args ) ) {
+            $args = array();
+        }
+
+        return array_merge( $defaults, $args );
+    }
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+    function esc_html( $text ) {
+        return $text;
+    }
+}
+
 if ( ! defined( 'CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY' ) ) {
     define( 'CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY', true );
 }
 
 require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php';
+require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php';

--- a/wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php
@@ -99,6 +99,33 @@ class Contifico_WooCommerce_Api_Contifico_Client {
     }
 
     /**
+     * Obtiene el inventario de una bodega específica.
+     *
+     * @param string $warehouse_id Identificador de la bodega.
+     * @param array  $params       Parámetros adicionales para la consulta.
+     *
+     * @return array|WP_Error
+     */
+    public function get_inventory_by_warehouse( $warehouse_id, array $params = array() ) {
+        if ( '' === $warehouse_id ) {
+            return $this->create_wp_error(
+                'contifico_missing_warehouse_id',
+                $this->translate( 'Debes especificar una bodega válida para consultar el inventario.' )
+            );
+        }
+
+        $warehouse_id = rawurlencode( (string) $warehouse_id );
+
+        return $this->request(
+            'GET',
+            sprintf( '/inventario/stock/bodega/%s/', $warehouse_id ),
+            array(
+                'query' => $params,
+            )
+        );
+    }
+
+    /**
      * Registra una factura en Contifico.
      *
      * @param array $invoice Datos de la factura a crear.

--- a/wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php
@@ -25,6 +25,16 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
     const CRON_HOOK = 'contifico_woocommerce_inventory_sync';
 
     /**
+     * Hook registrado en Action Scheduler para procesar cada lote.
+     */
+    const BATCH_ACTION = 'contifico_woocommerce_inventory_sync_batch';
+
+    /**
+     * Option que almacena el estado de la sincronización por lotes.
+     */
+    const BATCH_STATE_OPTION = 'contifico_woocommerce_inventory_batch_state';
+
+    /**
      * Option donde se guarda la bitácora del último proceso de sincronización.
      */
     const LOG_OPTION = 'contifico_woocommerce_inventory_log';
@@ -43,6 +53,21 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
      * Prefijo utilizado para almacenar notificaciones temporales.
      */
     const NOTICE_TRANSIENT_PREFIX = 'contifico_inventory_sync_notice_';
+
+    /**
+     * Prefijo de los transients que almacenan el stock de una bodega durante el proceso.
+     */
+    const STOCK_CACHE_TRANSIENT_PREFIX = 'contifico_inventory_stock_cache_';
+
+    /**
+     * Tamaño por defecto de cada lote.
+     */
+    const DEFAULT_BATCH_SIZE = 100;
+
+    /**
+     * Grupo utilizado para las acciones programadas del plugin.
+     */
+    const ACTION_SCHEDULER_GROUP = 'contifico-woocommerce';
 
     /**
      * Cliente HTTP para comunicarse con Contifico.
@@ -77,6 +102,7 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
     public function init_hooks() {
         add_action( 'init', array( $this, 'schedule_cron' ) );
         add_action( self::CRON_HOOK, array( $this, 'handle_scheduled_sync' ) );
+        add_action( self::BATCH_ACTION, array( $this, 'handle_batch_action' ), 10, 1 );
         add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
         add_action( 'admin_post_contifico_inventory_sync', array( $this, 'handle_admin_post_sync' ) );
     }
@@ -103,6 +129,29 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
      */
     public function handle_scheduled_sync() {
         $this->sync_inventory( 'scheduled' );
+    }
+
+    /**
+     * Acción registrada en Action Scheduler para procesar cada lote.
+     *
+     * @param array|int $payload Datos asociados al lote encolado.
+     *
+     * @return void
+     */
+    public function handle_batch_action( $payload = array() ) {
+        $step = 1;
+
+        if ( is_array( $payload ) && isset( $payload['step'] ) ) {
+            $step = absint( $payload['step'] );
+        } elseif ( is_numeric( $payload ) ) {
+            $step = absint( $payload );
+        }
+
+        if ( $step < 1 ) {
+            $step = 1;
+        }
+
+        $this->process_batch_step( $step );
     }
 
     /**
@@ -200,6 +249,21 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
      * @return array|WP_Error
      */
     public function sync_inventory( $context = 'manual' ) {
+        if ( $this->can_use_batch_processing() ) {
+            return $this->start_batch_sync( $context );
+        }
+
+        return $this->run_immediate_inventory_sync( $context );
+    }
+
+    /**
+     * Ejecuta la sincronización de inventario de forma inmediata sin lotes.
+     *
+     * @param string $context Contexto de ejecución.
+     *
+     * @return array|WP_Error
+     */
+    protected function run_immediate_inventory_sync( $context ) {
         $client = $this->get_client();
 
         if ( ! $client ) {
@@ -268,13 +332,601 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
     }
 
     /**
+     * Inicia la sincronización de inventario en modo por lotes utilizando Action Scheduler.
+     *
+     * @param string $context Contexto desde el cual se ejecuta la sincronización.
+     *
+     * @return array|WP_Error
+     */
+    public function start_batch_sync( $context = 'manual' ) {
+        if ( $this->is_batch_running() ) {
+            $error = new WP_Error(
+                'contifico_inventory_sync_running',
+                esc_html__( 'Ya existe una sincronización de inventario en ejecución.', 'contifico-woocommerce' )
+            );
+
+            $this->log( 'warning', $error->get_error_message(), array( 'context' => $context ) );
+
+            return $error;
+        }
+
+        $client = $this->get_client();
+
+        if ( ! $client ) {
+            $error = new WP_Error(
+                'contifico_missing_client',
+                esc_html__( 'No fue posible inicializar el cliente de Contifico.', 'contifico-woocommerce' )
+            );
+
+            $this->store_log( 'error', $error->get_error_message(), array( 'context' => $context ) );
+
+            return $error;
+        }
+
+        $response = $client->get_warehouses();
+
+        if ( is_wp_error( $response ) ) {
+            $this->log( 'error', $response->get_error_message(), array( 'context' => $context ) );
+            $this->store_log(
+                'error',
+                $response->get_error_message(),
+                array(
+                    'context'    => $context,
+                    'error_code' => $response->get_error_code(),
+                )
+            );
+
+            return $response;
+        }
+
+        $warehouses = $this->normalize_warehouses( $response );
+
+        if ( empty( $warehouses ) ) {
+            return $this->run_immediate_inventory_sync( $context );
+        }
+
+        $prepared_warehouses = array();
+
+        foreach ( $warehouses as $warehouse ) {
+            $warehouse_id = $this->get_warehouse_id( $warehouse );
+
+            if ( '' === $warehouse_id ) {
+                continue;
+            }
+
+            $prepared_warehouses[ $warehouse_id ] = array(
+                'name'             => $this->get_warehouse_name( $warehouse, $warehouse_id ),
+                'stock_cache_key'  => '',
+                'stock_initialized' => false,
+            );
+        }
+
+        if ( empty( $prepared_warehouses ) ) {
+            return $this->run_immediate_inventory_sync( $context );
+        }
+
+        $batch_size = $this->get_batch_size();
+
+        $state = array(
+            'context'            => $context,
+            'batch_size'         => $batch_size,
+            'current_step'       => 1,
+            'started_at'         => current_time( 'timestamp', true ),
+            'warehouses'         => $prepared_warehouses,
+            'cleanup_candidates' => array(),
+            'processed_products' => array(),
+            'items_processed'    => 0,
+            'products_cleaned'   => 0,
+            'errors'             => array(),
+        );
+
+        $existing_inventory = $this->get_products_with_inventory_meta();
+
+        if ( ! empty( $existing_inventory ) ) {
+            $state['cleanup_candidates'] = array_fill_keys( $existing_inventory, true );
+        }
+
+        $this->save_batch_state( $state );
+        $this->enqueue_batch_step( 1 );
+
+        $message = esc_html__( 'Se inició la sincronización de inventario en segundo plano.', 'contifico-woocommerce' );
+
+        $this->log( 'info', $message, array( 'context' => $context ) );
+
+        return array(
+            'message' => $message,
+            'summary' => array(
+                'status'     => 'queued',
+                'warehouses' => count( $prepared_warehouses ),
+                'batch_size' => $batch_size,
+                'context'    => $context,
+            ),
+        );
+    }
+
+    /**
+     * Ejecuta el procesamiento de un lote específico dentro de la sincronización.
+     *
+     * @param int $step Número del lote a procesar.
+     *
+     * @return void
+     */
+    protected function process_batch_step( $step ) {
+        $state = $this->get_batch_state();
+
+        if ( empty( $state ) ) {
+            return;
+        }
+
+        $context    = isset( $state['context'] ) ? $state['context'] : 'manual';
+        $batch_size = isset( $state['batch_size'] ) ? absint( $state['batch_size'] ) : $this->get_batch_size();
+        $batch_size = $batch_size > 0 ? $batch_size : $this->get_batch_size();
+
+        $client = $this->get_client();
+
+        if ( ! $client ) {
+            $error = new WP_Error(
+                'contifico_missing_client',
+                esc_html__( 'No fue posible inicializar el cliente de Contifico.', 'contifico-woocommerce' )
+            );
+
+            $this->log( 'error', $error->get_error_message(), array( 'context' => $context ) );
+            $this->store_log( 'error', $error->get_error_message(), array( 'context' => $context ) );
+            $this->clear_batch_state( $state );
+
+            return;
+        }
+
+        $response = $client->get_items(
+            array(
+                'result_page' => $step,
+                'result_size' => $batch_size,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            $this->log( 'error', $response->get_error_message(), array( 'context' => $context, 'step' => $step ) );
+            $this->store_log(
+                'error',
+                $response->get_error_message(),
+                array(
+                    'context'    => $context,
+                    'step'       => $step,
+                    'error_code' => $response->get_error_code(),
+                )
+            );
+            $this->clear_batch_state( $state );
+
+            return;
+        }
+
+        $products = $this->normalize_products_batch( $response );
+
+        if ( empty( $products ) ) {
+            $this->finalize_batch_processing( $state );
+            return;
+        }
+
+        $timestamp = current_time( 'mysql', true );
+
+        $warehouses_payload = $this->prepare_warehouses_payload_for_batch( $products, $state, $client );
+
+        $batch_summary = $this->process_inventory_response(
+            $warehouses_payload,
+            array(
+                'clean_stale'        => false,
+                'existing_inventory' => array_keys( isset( $state['cleanup_candidates'] ) ? $state['cleanup_candidates'] : array() ),
+                'timestamp'          => $timestamp,
+            )
+        );
+
+        if ( isset( $batch_summary['items_processed'] ) ) {
+            $state['items_processed'] = isset( $state['items_processed'] )
+                ? (int) $state['items_processed'] + (int) $batch_summary['items_processed']
+                : (int) $batch_summary['items_processed'];
+        }
+
+        if ( isset( $batch_summary['processed_product_ids'] ) && is_array( $batch_summary['processed_product_ids'] ) ) {
+            if ( ! isset( $state['processed_products'] ) || ! is_array( $state['processed_products'] ) ) {
+                $state['processed_products'] = array();
+            }
+
+            foreach ( $batch_summary['processed_product_ids'] as $product_id ) {
+                $product_id = absint( $product_id );
+
+                if ( ! $product_id ) {
+                    continue;
+                }
+
+                $state['processed_products'][ $product_id ] = true;
+
+                if ( isset( $state['cleanup_candidates'][ $product_id ] ) ) {
+                    unset( $state['cleanup_candidates'][ $product_id ] );
+                }
+            }
+        }
+
+        if ( ! empty( $batch_summary['errors'] ) ) {
+            $state['errors'] = isset( $state['errors'] ) && is_array( $state['errors'] )
+                ? array_merge( $state['errors'], $batch_summary['errors'] )
+                : $batch_summary['errors'];
+        }
+
+        $state['current_step'] = $step + 1;
+
+        $this->save_batch_state( $state );
+        $this->enqueue_batch_step( $step + 1 );
+    }
+
+    /**
+     * Construye la carga útil de bodegas para el lote actual.
+     *
+     * @param array                                      $products Productos normalizados devueltos por la API.
+     * @param array                                      $state    Estado actual de la sincronización.
+     * @param Contifico_WooCommerce_Api_Contifico_Client $client   Cliente HTTP de Contifico.
+     *
+     * @return array
+     */
+    protected function prepare_warehouses_payload_for_batch( array $products, array &$state, Contifico_WooCommerce_Api_Contifico_Client $client ) {
+        $payload = array();
+
+        if ( empty( $state['warehouses'] ) || ! is_array( $state['warehouses'] ) ) {
+            return $payload;
+        }
+
+        foreach ( $state['warehouses'] as $warehouse_id => &$warehouse_state ) {
+            $stock_map = $this->get_warehouse_stock_map( $client, $warehouse_id, $warehouse_state );
+
+            if ( is_wp_error( $stock_map ) ) {
+                $error_message = $stock_map->get_error_message();
+
+                if ( ! isset( $state['errors'] ) || ! is_array( $state['errors'] ) ) {
+                    $state['errors'] = array();
+                }
+
+                $state['errors'][] = $error_message;
+                $stock_map        = array();
+            }
+
+            $items = array();
+
+            foreach ( $products as $product ) {
+                $sku          = isset( $product['sku'] ) ? $product['sku'] : '';
+                $contifico_id = isset( $product['contifico_id'] ) ? (string) $product['contifico_id'] : '';
+                $name         = isset( $product['name'] ) ? $product['name'] : '';
+
+                $quantity = 0;
+
+                if ( '' !== $contifico_id && isset( $stock_map[ $contifico_id ] ) ) {
+                    $quantity = $stock_map[ $contifico_id ];
+                }
+
+                $items[] = array(
+                    'sku'              => $sku,
+                    'codigo'           => $sku,
+                    'codigo_principal' => $sku,
+                    'nombre'           => $name,
+                    'contifico_id'     => $contifico_id,
+                    'stock'            => $quantity,
+                );
+            }
+
+            $payload[] = array(
+                'id'     => $warehouse_id,
+                'nombre' => $warehouse_state['name'],
+                'items'  => $items,
+            );
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Obtiene el mapa de stock para una bodega, usando caché temporal cuando es posible.
+     *
+     * @param Contifico_WooCommerce_Api_Contifico_Client $client          Cliente HTTP.
+     * @param string                                     $warehouse_id    Identificador de la bodega.
+     * @param array                                      $warehouse_state Estado almacenado de la bodega.
+     *
+     * @return array|WP_Error
+     */
+    protected function get_warehouse_stock_map( Contifico_WooCommerce_Api_Contifico_Client $client, $warehouse_id, array &$warehouse_state ) {
+        $cache_key = isset( $warehouse_state['stock_cache_key'] ) ? $warehouse_state['stock_cache_key'] : '';
+
+        if ( '' !== $cache_key ) {
+            $cached = get_transient( $cache_key );
+
+            if ( false !== $cached && is_array( $cached ) ) {
+                return $cached;
+            }
+        }
+
+        $response = $client->get_inventory_by_warehouse( $warehouse_id );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $stock_map = $this->normalize_stock_response( $response );
+
+        $this->store_stock_cache_for_warehouse( $warehouse_id, $stock_map, $warehouse_state );
+
+        return $stock_map;
+    }
+
+    /**
+     * Guarda en un transient el stock asociado a una bodega.
+     *
+     * @param string $warehouse_id    Identificador de la bodega.
+     * @param array  $stock_map       Mapa de existencias por producto.
+     * @param array  $warehouse_state Estado actual de la bodega.
+     *
+     * @return void
+     */
+    protected function store_stock_cache_for_warehouse( $warehouse_id, array $stock_map, array &$warehouse_state ) {
+        $ttl = apply_filters( 'contifico_woocommerce_inventory_stock_cache_ttl', HOUR_IN_SECONDS );
+
+        if ( isset( $warehouse_state['stock_cache_key'] ) && '' !== $warehouse_state['stock_cache_key'] ) {
+            set_transient( $warehouse_state['stock_cache_key'], $stock_map, $ttl );
+        } else {
+            $key = self::STOCK_CACHE_TRANSIENT_PREFIX . md5( $warehouse_id . '|' . microtime() . '|' . wp_rand() );
+            set_transient( $key, $stock_map, $ttl );
+            $warehouse_state['stock_cache_key'] = $key;
+        }
+
+        $warehouse_state['stock_initialized'] = true;
+    }
+
+    /**
+     * Normaliza la respuesta de productos para trabajar siempre con una lista uniforme.
+     *
+     * @param mixed $response Respuesta de la API de Contifico.
+     *
+     * @return array
+     */
+    protected function normalize_products_batch( $response ) {
+        if ( empty( $response ) ) {
+            return array();
+        }
+
+        if ( isset( $response['results'] ) && is_array( $response['results'] ) ) {
+            $response = $response['results'];
+        } elseif ( isset( $response['data'] ) && is_array( $response['data'] ) ) {
+            $response = $response['data'];
+        }
+
+        if ( ! is_array( $response ) ) {
+            return array();
+        }
+
+        if ( ! $this->is_list( $response ) ) {
+            $response = array( $response );
+        }
+
+        $products = array();
+
+        foreach ( $response as $item ) {
+            if ( ! is_array( $item ) ) {
+                continue;
+            }
+
+            $contifico_id = $this->find_value_in_item( $item, array( 'id', 'producto_id', 'product_id', 'id_producto' ) );
+            $sku          = $this->find_value_in_item( $item, array( 'sku', 'codigo', 'codigo_principal', 'codigo_auxiliar' ) );
+
+            if ( '' === $contifico_id || '' === $sku ) {
+                continue;
+            }
+
+            $products[] = array(
+                'contifico_id' => (string) $contifico_id,
+                'sku'          => (string) $sku,
+                'name'         => $this->find_value_in_item( $item, array( 'nombre', 'name', 'descripcion', 'description' ) ),
+                'raw'          => $item,
+            );
+        }
+
+        return $products;
+    }
+
+    /**
+     * Busca el primer valor válido dentro de un arreglo utilizando varias claves posibles.
+     *
+     * @param array $item Arreglo de datos.
+     * @param array $keys Claves a evaluar.
+     *
+     * @return string
+     */
+    protected function find_value_in_item( array $item, array $keys ) {
+        foreach ( $keys as $key ) {
+            if ( isset( $item[ $key ] ) && '' !== $item[ $key ] ) {
+                return (string) $item[ $key ];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Convierte la respuesta de stock de Contifico en un mapa por ID de producto.
+     *
+     * @param mixed $response Datos crudos de la API.
+     *
+     * @return array
+     */
+    protected function normalize_stock_response( $response ) {
+        if ( empty( $response ) ) {
+            return array();
+        }
+
+        if ( isset( $response['results'] ) && is_array( $response['results'] ) ) {
+            $response = $response['results'];
+        } elseif ( isset( $response['data'] ) && is_array( $response['data'] ) ) {
+            $response = $response['data'];
+        }
+
+        if ( ! is_array( $response ) ) {
+            return array();
+        }
+
+        if ( ! $this->is_list( $response ) ) {
+            $response = array( $response );
+        }
+
+        $stock_map = array();
+
+        foreach ( $response as $row ) {
+            if ( ! is_array( $row ) ) {
+                continue;
+            }
+
+            $product_id = $this->find_value_in_item( $row, array( 'producto_id', 'product_id', 'id_producto', 'id' ) );
+
+            if ( '' === $product_id ) {
+                continue;
+            }
+
+            $quantity = $this->find_value_in_item( $row, array( 'cantidad_stock', 'cantidad', 'stock', 'quantity' ) );
+
+            if ( '' === $quantity ) {
+                $quantity = 0;
+            }
+
+            if ( function_exists( 'wc_stock_amount' ) ) {
+                $quantity = wc_stock_amount( $quantity );
+            } else {
+                $quantity = (float) $quantity;
+            }
+
+            $stock_map[ (string) $product_id ] = (float) $quantity;
+        }
+
+        return $stock_map;
+    }
+
+    /**
+     * Finaliza la sincronización por lotes limpiando los productos pendientes y registrando la bitácora.
+     *
+     * @param array $state Estado acumulado de la sincronización.
+     *
+     * @return void
+     */
+    protected function finalize_batch_processing( array $state ) {
+        $context = isset( $state['context'] ) ? $state['context'] : 'manual';
+
+        $cleanup_candidates = array_keys( isset( $state['cleanup_candidates'] ) ? $state['cleanup_candidates'] : array() );
+        $products_cleaned   = isset( $state['products_cleaned'] ) ? (int) $state['products_cleaned'] : 0;
+
+        if ( ! empty( $cleanup_candidates ) ) {
+            $products_cleaned += $this->cleanup_stale_inventory( array_map( 'absint', $cleanup_candidates ), array() );
+        }
+
+        $processed_products = isset( $state['processed_products'] ) && is_array( $state['processed_products'] )
+            ? count( $state['processed_products'] )
+            : 0;
+
+        $summary = array(
+            'warehouses'       => isset( $state['warehouses'] ) && is_array( $state['warehouses'] ) ? count( $state['warehouses'] ) : 0,
+            'products_updated' => $processed_products,
+            'items_processed'  => isset( $state['items_processed'] ) ? (int) $state['items_processed'] : 0,
+            'products_cleaned' => $products_cleaned,
+            'errors'           => isset( $state['errors'] ) && is_array( $state['errors'] ) ? $state['errors'] : array(),
+            'mode'             => 'batch',
+        );
+
+        if ( ! empty( $summary['errors'] ) ) {
+            foreach ( $summary['errors'] as $error_message ) {
+                $this->log( 'warning', $error_message, array( 'context' => $context ) );
+            }
+        }
+
+        $message = sprintf(
+            /* translators: 1: context label, 2: warehouse count, 3: product count */
+            esc_html__( 'Sincronización de inventario %1$s completada. Bodegas procesadas: %2$d. Productos actualizados: %3$d.', 'contifico-woocommerce' ),
+            $this->get_context_label( $context ),
+            isset( $summary['warehouses'] ) ? (int) $summary['warehouses'] : 0,
+            (int) $summary['products_updated']
+        );
+
+        $this->store_log(
+            'success',
+            $message,
+            array_merge(
+                $summary,
+                array(
+                    'context' => $context,
+                )
+            )
+        );
+
+        $this->log( 'info', $message, array( 'context' => $context ) );
+
+        $state['products_cleaned'] = $products_cleaned;
+        $state['finished']         = true;
+
+        $this->clear_batch_state( $state );
+    }
+
+    /**
      * Procesa la información devuelta por la API y actualiza el stock de productos.
      *
      * @param array $warehouses Listado de bodegas.
      *
      * @return array
      */
-    protected function process_inventory_response( array $warehouses ) {
+    protected function process_inventory_response( array $warehouses, array $args = array() ) {
+        $args = wp_parse_args(
+            $args,
+            array(
+                'existing_inventory' => null,
+                'clean_stale'        => true,
+                'timestamp'          => null,
+            )
+        );
+
+        $timestamp = $args['timestamp'];
+        if ( null === $timestamp ) {
+            $timestamp = current_time( 'mysql', true );
+        }
+
+        $existing_inventory = $args['existing_inventory'];
+        if ( null === $existing_inventory ) {
+            $existing_inventory = $this->get_products_with_inventory_meta();
+        } else {
+            $existing_inventory = array_map( 'absint', (array) $existing_inventory );
+            $existing_inventory = array_values( array_filter( array_unique( $existing_inventory ) ) );
+        }
+
+        $built_inventory = $this->build_inventory_map( $warehouses, $timestamp );
+
+        $products_cleaned = 0;
+        if ( $args['clean_stale'] ) {
+            $products_cleaned = $this->cleanup_stale_inventory(
+                $existing_inventory,
+                array_keys( $built_inventory['grouped_inventory'] )
+            );
+        }
+
+        $this->persist_grouped_inventory( $built_inventory['grouped_inventory'] );
+
+        return array(
+            'warehouses'             => $built_inventory['warehouses_count'],
+            'products_updated'       => count( $built_inventory['updated_products'] ),
+            'items_processed'        => $built_inventory['items_processed'],
+            'products_cleaned'       => $products_cleaned,
+            'errors'                 => $built_inventory['errors'],
+            'processed_product_ids'  => array_keys( $built_inventory['updated_products'] ),
+        );
+    }
+
+    /**
+     * Construye un mapa de inventario agrupado por producto y bodega.
+     *
+     * @param array  $warehouses Datos de bodegas recibidos desde la API.
+     * @param string $timestamp  Marca de tiempo que se almacenará en los metadatos.
+     *
+     * @return array
+     */
+    protected function build_inventory_map( array $warehouses, $timestamp ) {
         $grouped_inventory = array();
         $updated_products  = array();
         $errors            = array();
@@ -347,13 +999,63 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
                     'warehouse_id'   => $warehouse_id,
                     'name'           => $warehouse_name,
                     'stock'          => $stock,
-                    'updated_at_gmt' => current_time( 'mysql', true ),
+                    'updated_at_gmt' => $timestamp,
                 );
 
                 $updated_products[ $product_id ] = true;
             }
         }
 
+        return array(
+            'grouped_inventory' => $grouped_inventory,
+            'updated_products'  => $updated_products,
+            'errors'            => $errors,
+            'warehouses_count'  => $warehouses_count,
+            'items_processed'   => $items_processed,
+        );
+    }
+
+    /**
+     * Elimina los metadatos de inventario que no aparecen en la respuesta procesada.
+     *
+     * @param array $existing_inventory IDs de productos que actualmente tienen metadata.
+     * @param array $products_in_response IDs encontrados en la respuesta actual.
+     *
+     * @return int Número de productos limpiados.
+     */
+    protected function cleanup_stale_inventory( array $existing_inventory, array $products_in_response ) {
+        $products_in_response = array_map( 'absint', $products_in_response );
+        $products_in_response = array_values( array_filter( array_unique( $products_in_response ) ) );
+
+        $stale_products   = array_diff( $existing_inventory, $products_in_response );
+        $products_cleaned = 0;
+
+        if ( empty( $stale_products ) ) {
+            return 0;
+        }
+
+        foreach ( $stale_products as $product_id ) {
+            $product_id = absint( $product_id );
+
+            if ( ! $product_id ) {
+                continue;
+            }
+
+            delete_post_meta( $product_id, self::META_KEY );
+            $products_cleaned++;
+        }
+
+        return $products_cleaned;
+    }
+
+    /**
+     * Guarda la información de inventario agrupada por producto.
+     *
+     * @param array $grouped_inventory Datos preparados por {@see build_inventory_map}.
+     *
+     * @return void
+     */
+    protected function persist_grouped_inventory( array $grouped_inventory ) {
         foreach ( $grouped_inventory as $product_id => $warehouses_stock ) {
             if ( empty( $warehouses_stock ) ) {
                 delete_post_meta( $product_id, self::META_KEY );
@@ -362,13 +1064,37 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
 
             update_post_meta( $product_id, self::META_KEY, $warehouses_stock );
         }
+    }
 
-        return array(
-            'warehouses'       => $warehouses_count,
-            'products_updated' => count( $updated_products ),
-            'items_processed'  => $items_processed,
-            'errors'           => $errors,
+    /**
+     * Obtiene el listado de productos que actualmente almacenan el meta de inventario.
+     *
+     * @return array
+     */
+    protected function get_products_with_inventory_meta() {
+        if ( ! function_exists( 'get_posts' ) ) {
+            return array();
+        }
+
+        $posts = get_posts(
+            array(
+                'post_type'      => array( 'product', 'product_variation' ),
+                'meta_key'       => self::META_KEY,
+                'fields'         => 'ids',
+                'posts_per_page' => -1,
+                'post_status'    => 'any',
+                'no_found_rows'  => true,
+                'suppress_filters' => true,
+            )
         );
+
+        if ( ! is_array( $posts ) ) {
+            return array();
+        }
+
+        $posts = array_map( 'absint', $posts );
+
+        return array_values( array_filter( array_unique( $posts ) ) );
     }
 
     /**
@@ -448,7 +1174,9 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
             if ( isset( $item[ $key ] ) && '' !== $item[ $key ] ) {
                 $candidate = absint( $item[ $key ] );
 
-                if ( $candidate && 'product' === get_post_type( $candidate ) ) {
+                $post_type = $candidate ? get_post_type( $candidate ) : '';
+
+                if ( $candidate && in_array( $post_type, array( 'product', 'product_variation' ), true ) ) {
                     return $candidate;
                 }
             }
@@ -489,7 +1217,7 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
             }
         }
 
-        foreach ( array( 'product_id', 'producto_id', 'id_producto', 'id' ) as $key ) {
+        foreach ( array( 'product_id', 'producto_id', 'id_producto', 'id', 'contifico_id' ) as $key ) {
             if ( isset( $item[ $key ] ) && '' !== $item[ $key ] ) {
                 return (string) $item[ $key ];
             }
@@ -624,6 +1352,87 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
     }
 
     /**
+     * Obtiene el estado actual de la sincronización por lotes.
+     *
+     * @return array
+     */
+    protected function get_batch_state() {
+        $state = get_option( self::BATCH_STATE_OPTION, array() );
+
+        return is_array( $state ) ? $state : array();
+    }
+
+    /**
+     * Guarda el estado de la sincronización por lotes.
+     *
+     * @param array $state Datos del estado.
+     *
+     * @return void
+     */
+    protected function save_batch_state( array $state ) {
+        update_option( self::BATCH_STATE_OPTION, $state, false );
+    }
+
+    /**
+     * Elimina el estado almacenado y limpia los transients asociados.
+     *
+     * @param array|null $state Estado a limpiar. Si es null se obtiene automáticamente.
+     *
+     * @return void
+     */
+    protected function clear_batch_state( ?array $state = null ) {
+        if ( null === $state ) {
+            $state = $this->get_batch_state();
+        }
+
+        if ( isset( $state['warehouses'] ) && is_array( $state['warehouses'] ) ) {
+            foreach ( $state['warehouses'] as $warehouse ) {
+                if ( isset( $warehouse['stock_cache_key'] ) && '' !== $warehouse['stock_cache_key'] ) {
+                    delete_transient( $warehouse['stock_cache_key'] );
+                }
+            }
+        }
+
+        delete_option( self::BATCH_STATE_OPTION );
+    }
+
+    /**
+     * Indica si existe un proceso de sincronización por lotes en curso.
+     *
+     * @return bool
+     */
+    protected function is_batch_running() {
+        $state = $this->get_batch_state();
+
+        return ! empty( $state ) && empty( $state['finished'] );
+    }
+
+    /**
+     * Encola la siguiente acción de procesamiento en Action Scheduler.
+     *
+     * @param int $step Paso a ejecutar.
+     *
+     * @return void
+     */
+    protected function enqueue_batch_step( $step ) {
+        if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+            return;
+        }
+
+        $step = max( 1, absint( $step ) );
+
+        as_enqueue_async_action(
+            self::BATCH_ACTION,
+            array(
+                array(
+                    'step' => $step,
+                ),
+            ),
+            self::ACTION_SCHEDULER_GROUP
+        );
+    }
+
+    /**
      * Envía mensajes al logger si existe.
      *
      * @param string $level   Nivel del mensaje (info, warning, error).
@@ -659,6 +1468,31 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
         }
 
         return sanitize_text_field( $value );
+    }
+
+    /**
+     * Determina el tamaño del lote a utilizar durante la sincronización.
+     *
+     * @return int
+     */
+    protected function get_batch_size() {
+        $size = apply_filters( 'contifico_woocommerce_inventory_batch_size', self::DEFAULT_BATCH_SIZE );
+        $size = absint( $size );
+
+        if ( $size <= 0 ) {
+            $size = self::DEFAULT_BATCH_SIZE;
+        }
+
+        return $size;
+    }
+
+    /**
+     * Verifica si el entorno actual permite utilizar Action Scheduler.
+     *
+     * @return bool
+     */
+    protected function can_use_batch_processing() {
+        return function_exists( 'as_enqueue_async_action' );
     }
 
     /**


### PR DESCRIPTION
## Summary
- introduce an Action Scheduler-driven inventory sync that batches Contifico products, caches warehouse stock, tracks progress and finalizes cleanup once the queue finishes
- refactor the inventory processor into reusable helpers so batches can skip cleanup until the final step while still returning processed product ids for deferred metadata removal
- expose the Contifico client endpoint for warehouse stock, stub missing WordPress helpers for tests and cover the new batch bootstrap and cleanup behaviour with unit tests

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d33a7a22788332b2d890da3dd9c42d