### PR TITLE
Skip warehouse payload when inventory fetch fails

### DIFF
--- a/tests/InventorySyncTest.php
+++ b/tests/InventorySyncTest.php
@@ -14,6 +14,14 @@ class Testable_Contifico_WooCommerce_Sync_Inventory_Sync extends Contifico_WooCo
         return $this->process_inventory_response( $warehouses, $args );
     }
 
+    public function call_prepare_warehouses_payload_for_batch(
+        array $products,
+        array &$state,
+        Contifico_WooCommerce_Api_Contifico_Client $client
+    ) {
+        return $this->prepare_warehouses_payload_for_batch( $products, $state, $client );
+    }
+
     public function set_client( $client ) {
         $this->client = $client;
 
@@ -163,6 +171,50 @@ class InventorySyncTest extends TestCase {
 
         $this->assertSame( 0, $summary['products_cleaned'] );
         $this->assertSame( array( 10 ), $summary['processed_product_ids'] );
+    }
+
+    public function test_prepare_warehouses_payload_skips_warehouse_when_stock_fetch_fails() {
+        $sync = new class() extends Testable_Contifico_WooCommerce_Sync_Inventory_Sync {
+            protected function get_warehouse_stock_map(
+                Contifico_WooCommerce_Api_Contifico_Client $client,
+                $warehouse_id,
+                array &$warehouse_state
+            ) {
+                return new WP_Error(
+                    'contifico_inventory_fetch_failed',
+                    sprintf( 'Failed to fetch inventory for warehouse %s.', $warehouse_id )
+                );
+            }
+        };
+
+        $client = new Contifico_WooCommerce_Api_Contifico_Client();
+
+        $state = array(
+            'warehouses' => array(
+                'main' => array(
+                    'name'              => 'Principal',
+                    'stock_cache_key'   => '',
+                    'stock_initialized' => false,
+                ),
+            ),
+        );
+
+        $products = array(
+            array(
+                'sku'          => 'SKU-123',
+                'contifico_id' => '123',
+                'name'         => 'Producto de prueba',
+            ),
+        );
+
+        $payload = $sync->call_prepare_warehouses_payload_for_batch( $products, $state, $client );
+
+        $this->assertSame( array(), $payload );
+        $this->assertArrayHasKey( 'errors', $state );
+        $this->assertSame(
+            array( 'Failed to fetch inventory for warehouse main.' ),
+            $state['errors']
+        );
     }
 
     public function test_start_batch_sync_initializes_state_and_schedules_action() {

--- a/wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php
@@ -585,7 +585,18 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
                 }
 
                 $state['errors'][] = $error_message;
-                $stock_map        = array();
+
+                $cached_stock_map = false;
+
+                if ( isset( $warehouse_state['stock_cache_key'] ) && '' !== $warehouse_state['stock_cache_key'] ) {
+                    $cached_stock_map = get_transient( $warehouse_state['stock_cache_key'] );
+                }
+
+                if ( false === $cached_stock_map || ! is_array( $cached_stock_map ) ) {
+                    continue;
+                }
+
+                $stock_map = $cached_stock_map;
             }
 
             $items = array();


### PR DESCRIPTION
## Summary
- skip building batch payloads when fetching warehouse stock returns an error, while reusing cached inventory data when available
- expose the batch payload helper through the test shim and cover the error path with a regression test

## Testing
- composer test *(fails: Contifico_WooCommerce_Sync_Inventory_Sync::get_products_with_inventory_meta() is defined twice in class-inventory-sync.php)*

------
https://chatgpt.com/codex/tasks/task_e_68d3899a138c8332a71cf76489053b41