### PR TITLE
Add inventory transfers, price sync, and diagnostics controls

### DIFF
--- a/tests/ContificoClientTest.php
+++ b/tests/ContificoClientTest.php
@@ -203,4 +203,78 @@ class ContificoClientTest extends TestCase {
         $this->assertSame( 'PROD123', $payload['detalles'][0]['producto_id'] );
         $this->assertSame( '5.5', $payload['detalles'][0]['cantidad'] );
     }
+
+    public function test_create_inventory_transfer_sends_payload() {
+        Functions\expect( 'get_option' )
+            ->once()
+            ->with( 'contifico_woocommerce_settings', array() )
+            ->andReturn(
+                array(
+                    'api_url' => 'https://api.example.com',
+                    'api_key' => 'token-123',
+                )
+            );
+
+        Functions\when( 'wc_stock_amount' )
+            ->alias( function ( $value ) {
+                return (float) $value;
+            } );
+
+        $captured_args = null;
+
+        Functions\expect( 'wp_remote_request' )
+            ->once()
+            ->with(
+                'https://api.example.com/movimiento-inventario/',
+                \Mockery::on(
+                    function ( $args ) use ( &$captured_args ) {
+                        $captured_args = $args;
+
+                        return isset( $args['method'] )
+                            && 'POST' === $args['method']
+                            && isset( $args['headers']['Authorization'] )
+                            && 'token-123' === $args['headers']['Authorization'];
+                    }
+                )
+            )
+            ->andReturn( array( 'body' => '', 'response' => array( 'code' => 200 ) ) );
+
+        Functions\expect( 'wp_remote_retrieve_response_code' )
+            ->once()
+            ->andReturn( 200 );
+
+        Functions\expect( 'wp_remote_retrieve_body' )
+            ->once()
+            ->andReturn( '[]' );
+
+        $client = new Contifico_WooCommerce_Api_Contifico_Client();
+        $result = $client->create_inventory_transfer(
+            array(
+                'bodega_id'         => 'main',
+                'bodega_destino_id' => 'web',
+                'descripcion'       => 'Prueba',
+                'detalles'          => array(
+                    array(
+                        'producto_id' => 'P-1',
+                        'cantidad'    => 2,
+                    ),
+                    array(
+                        'producto_id' => 'P-2',
+                        'cantidad'    => 1,
+                    ),
+                ),
+            )
+        );
+
+        $this->assertIsArray( $result );
+        $this->assertNotNull( $captured_args );
+
+        $payload = json_decode( $captured_args['body'], true );
+
+        $this->assertSame( 'TRA', $payload['tipo'] );
+        $this->assertSame( 'main', $payload['bodega_id'] );
+        $this->assertSame( 'web', $payload['bodega_destino_id'] );
+        $this->assertCount( 2, $payload['detalles'] );
+        $this->assertEquals( 2.0, $payload['detalles'][0]['cantidad'] );
+    }
 }

--- a/tests/InventorySyncTest.php
+++ b/tests/InventorySyncTest.php
@@ -6,6 +6,16 @@ use PHPUnit\Framework\TestCase;
 
 class Testable_Contifico_WooCommerce_Sync_Inventory_Sync extends Contifico_WooCommerce_Sync_Inventory_Sync {
 
+    public function __construct( $client = null, $logger = null, $settings = null ) {
+        parent::__construct( $client, $logger, $settings );
+
+        if ( null === $this->settings_cache ) {
+            $this->settings_cache = array(
+                'inventory_price_list' => 'none',
+            );
+        }
+    }
+
     public function call_resolve_product_id( array $item ) {
         return $this->resolve_product_id( $item );
     }
@@ -16,6 +26,14 @@ class Testable_Contifico_WooCommerce_Sync_Inventory_Sync extends Contifico_WooCo
 
     public function set_client( $client ) {
         $this->client = $client;
+    }
+
+    public function set_settings_cache( array $settings ) {
+        $this->settings_cache = $settings;
+    }
+
+    public function call_maybe_sync_product_prices( array $product_map ) {
+        $this->maybe_sync_product_prices( $product_map );
     }
 }
 
@@ -251,6 +269,48 @@ class InventorySyncTest extends TestCase {
         $this->assertSame( 1, $result['summary']['warehouses'] );
         $this->assertSame( Contifico_WooCommerce_Sync_Inventory_Sync::DEFAULT_BATCH_SIZE, $result['summary']['batch_size'] );
 
+    }
+
+    public function test_maybe_sync_product_prices_updates_regular_price() {
+        $product = new WC_Product(
+            array(
+                'id'            => 10,
+                'regular_price' => '9.99',
+                'meta'          => array( '_contifico_product_id' => 'P-001' ),
+            )
+        );
+
+        $sync = new Testable_Contifico_WooCommerce_Sync_Inventory_Sync();
+        $sync->set_settings_cache(
+            array(
+                'inventory_price_list' => 'pvp1',
+            )
+        );
+
+        Functions\when( 'wc_format_decimal' )
+            ->alias(
+                function ( $value, $decimals = 2 ) {
+                    return number_format( (float) $value, $decimals, '.', '' );
+                }
+            );
+
+        Functions\when( 'wc_get_price_decimals' )
+            ->justReturn( 2 );
+
+        $GLOBALS['contifico_wc_test_products'][10] = $product;
+
+        $sync->call_maybe_sync_product_prices(
+            array(
+                10 => array( 'price' => '15.5' ),
+            )
+        );
+
+        unset( $GLOBALS['contifico_wc_test_products'][10] );
+        if ( empty( $GLOBALS['contifico_wc_test_products'] ) ) {
+            unset( $GLOBALS['contifico_wc_test_products'] );
+        }
+
+        $this->assertSame( '15.50', $product->get_regular_price() );
     }
 }
 

--- a/tests/InventoryTransferManagerTest.php
+++ b/tests/InventoryTransferManagerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class InventoryTransferManagerTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        \Mockery::close();
+        parent::tearDown();
+    }
+
+    protected function build_settings_manager( array $overrides = array() ) {
+        $defaults = array(
+            'inventory_transfer_enabled'           => 'yes',
+            'inventory_transfer_source'            => 'main',
+            'inventory_transfer_destination'       => 'web',
+            'inventory_transfer_decrease_statuses' => array( 'wc-processing' ),
+            'inventory_transfer_restore_statuses'  => array( 'wc-cancelled' ),
+        );
+
+        $settings = array_merge( $defaults, $overrides );
+
+        $manager = \Mockery::mock( Contifico_WooCommerce_Admin_Settings::class );
+        $manager->shouldReceive( 'get_settings' )
+            ->andReturn( $settings );
+
+        return $manager;
+    }
+
+    public function test_status_change_triggers_transfer_when_configured() {
+        $settings = $this->build_settings_manager();
+        $client   = \Mockery::mock( Contifico_WooCommerce_Api_Contifico_Client::class );
+        $logger   = \Mockery::mock( 'WC_Logger' );
+        $logger->shouldIgnoreMissing();
+
+        Functions\when( 'wc_stock_amount' )
+            ->alias( function ( $value ) {
+                return (float) $value;
+            } );
+
+        Functions\expect( 'current_time' )
+            ->once()
+            ->with( 'mysql', true )
+            ->andReturn( '2024-01-01 00:00:00' );
+
+        $client->shouldReceive( 'create_inventory_transfer' )
+            ->once()
+            ->with( \Mockery::on( function ( $payload ) {
+                return 'main' === $payload['bodega_id']
+                    && 'web' === $payload['bodega_destino_id']
+                    && 'TRA' === $payload['tipo']
+                    && 1 === count( $payload['detalles'] )
+                    && 'P-001' === $payload['detalles'][0]['producto_id']
+                    && abs( $payload['detalles'][0]['cantidad'] - 2 ) < 0.0001;
+            } ) )
+            ->andReturn( array( 'codigo' => 'MOV-1' ) );
+
+        $product = new WC_Product(
+            array(
+                'id'   => 10,
+                'meta' => array( '_contifico_product_id' => 'P-001' ),
+            )
+        );
+
+        $item = new WC_Order_Item_Product(
+            array(
+                'product'  => $product,
+                'quantity' => 2,
+                'meta'     => array( '_reduced_stock' => 2 ),
+            )
+        );
+
+        $order = new WC_Order(
+            array(
+                'id'    => 123,
+                'items' => array( $item ),
+            )
+        );
+
+        $manager = new Contifico_WooCommerce_Inventory_Transfer_Manager( $settings, $client, $logger );
+        $manager->maybe_handle_status_change( 123, 'pending', 'processing', $order );
+
+        $state = $order->get_meta( Contifico_WooCommerce_Inventory_Transfer_Manager::META_KEY );
+
+        $this->assertIsArray( $state );
+        $this->assertTrue( $state['reserved'] );
+        $this->assertSame( 'MOV-1', $state['last_reference'] );
+        $this->assertNotEmpty( $order->get_notes() );
+    }
+
+    public function test_restore_transfer_reverts_when_state_exists() {
+        $settings = $this->build_settings_manager();
+        $client   = \Mockery::mock( Contifico_WooCommerce_Api_Contifico_Client::class );
+        $logger   = \Mockery::mock( 'WC_Logger' );
+        $logger->shouldIgnoreMissing();
+
+        Functions\expect( 'current_time' )
+            ->once()
+            ->with( 'mysql', true )
+            ->andReturn( '2024-01-02 00:00:00' );
+
+        $client->shouldReceive( 'create_inventory_transfer' )
+            ->once()
+            ->with( \Mockery::on( function ( $payload ) {
+                return 'web' === $payload['bodega_id']
+                    && 'main' === $payload['bodega_destino_id']
+                    && 1 === count( $payload['detalles'] )
+                    && abs( $payload['detalles'][0]['cantidad'] - 2 ) < 0.0001;
+            } ) )
+            ->andReturn( array( 'codigo' => 'MOV-2' ) );
+
+        $order = new WC_Order(
+            array(
+                'id'    => 500,
+                'items' => array(),
+            )
+        );
+
+        $order->update_meta_data(
+            Contifico_WooCommerce_Inventory_Transfer_Manager::META_KEY,
+            array(
+                'reserved'    => true,
+                'items'       => array(
+                    array(
+                        'producto_id' => 'P-001',
+                        'cantidad'    => 2,
+                    ),
+                ),
+                'source'      => 'main',
+                'destination' => 'web',
+            )
+        );
+
+        $manager = new Contifico_WooCommerce_Inventory_Transfer_Manager( $settings, $client, $logger );
+        $manager->maybe_handle_status_change( 500, 'processing', 'cancelled', $order );
+
+        $state = $order->get_meta( Contifico_WooCommerce_Inventory_Transfer_Manager::META_KEY );
+
+        $this->assertIsArray( $state );
+        $this->assertFalse( $state['reserved'] );
+        $this->assertSame( array(), $state['items'] );
+        $this->assertSame( 'MOV-2', $state['last_reference'] );
+    }
+
+    public function test_manager_skips_when_feature_disabled() {
+        $settings = $this->build_settings_manager(
+            array(
+                'inventory_transfer_enabled' => 'no',
+            )
+        );
+
+        $client = \Mockery::mock( Contifico_WooCommerce_Api_Contifico_Client::class );
+        $client->shouldReceive( 'create_inventory_transfer' )->never();
+
+        $logger = \Mockery::mock( 'WC_Logger' );
+        $logger->shouldIgnoreMissing();
+
+        $order = new WC_Order( array( 'id' => 10 ) );
+
+        $manager = new Contifico_WooCommerce_Inventory_Transfer_Manager( $settings, $client, $logger );
+        $manager->maybe_handle_status_change( 10, 'pending', 'processing', $order );
+
+        $this->assertSame( '', $order->get_meta( Contifico_WooCommerce_Inventory_Transfer_Manager::META_KEY ) );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,10 +10,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/stubs/class-wp-error.php';
+require_once __DIR__ . '/stubs/class-wc-product.php';
+require_once __DIR__ . '/stubs/class-wc-order.php';
+require_once __DIR__ . '/stubs/class-wc-order-item-product.php';
 
 if ( ! function_exists( 'is_wp_error' ) ) {
     function is_wp_error( $thing ) {
         return $thing instanceof WP_Error;
+    }
+}
+
+if ( ! function_exists( 'wc_get_product' ) ) {
+    function wc_get_product( $product_id ) {
+        $key = 'contifico_wc_test_products';
+
+        if ( isset( $GLOBALS[ $key ] ) && is_array( $GLOBALS[ $key ] ) && isset( $GLOBALS[ $key ][ $product_id ] ) ) {
+            return $GLOBALS[ $key ][ $product_id ];
+        }
+
+        return null;
     }
 }
 
@@ -56,6 +71,7 @@ if ( ! defined( 'CONTIFICO_WOOCOMMERCE_DISABLE_RETRY_DELAY' ) ) {
 
 require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php';
 require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php';
+require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/class-inventory-transfer-manager.php';
 require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/class-tax-helper.php';
 require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/admin/class-settings.php';
 require_once __DIR__ . '/../wp-content/plugins/contifico-woocommerce/includes/class-invoice-manager.php';

--- a/tests/stubs/class-wc-order-item-product.php
+++ b/tests/stubs/class-wc-order-item-product.php
@@ -1,0 +1,42 @@
+<?php
+if ( ! class_exists( 'WC_Order_Item_Product' ) ) {
+    class WC_Order_Item_Product {
+        protected $product;
+        protected $quantity;
+        protected $meta = array();
+
+        public function __construct( array $args = array() ) {
+            $defaults = array(
+                'product'  => null,
+                'quantity' => 0,
+                'meta'     => array(),
+            );
+
+            $args = array_merge( $defaults, $args );
+
+            $this->product  = $args['product'];
+            $this->quantity = $args['quantity'];
+            $this->meta     = is_array( $args['meta'] ) ? $args['meta'] : array();
+        }
+
+        public function get_product() {
+            return $this->product;
+        }
+
+        public function get_quantity() {
+            return $this->quantity;
+        }
+
+        public function get_meta( $key, $single = true ) {
+            if ( isset( $this->meta[ $key ] ) ) {
+                return $this->meta[ $key ];
+            }
+
+            return $single ? '' : array();
+        }
+
+        public function set_meta( $key, $value ) {
+            $this->meta[ $key ] = $value;
+        }
+    }
+}

--- a/tests/stubs/class-wc-order.php
+++ b/tests/stubs/class-wc-order.php
@@ -1,0 +1,136 @@
+<?php
+if ( ! class_exists( 'WC_Order' ) ) {
+    class WC_Order {
+        protected $id;
+        protected $total;
+        protected $meta = array();
+        protected $items = array();
+        protected $billing = array();
+        protected $notes = array();
+        protected $order_number = '';
+
+        public function __construct( array $args = array() ) {
+            $defaults = array(
+                'id'                 => 0,
+                'total'              => 0,
+                'meta'               => array(),
+                'items'              => array(),
+                'billing_company'    => '',
+                'billing_first_name' => '',
+                'billing_last_name'  => '',
+                'billing_email'      => '',
+                'billing_phone'      => '',
+                'billing_address_1'  => '',
+                'billing_address_2'  => '',
+                'billing_country'    => '',
+                'order_number'       => '',
+            );
+
+            $args = array_merge( $defaults, $args );
+
+            $this->id           = (int) $args['id'];
+            $this->total        = $args['total'];
+            $this->meta         = is_array( $args['meta'] ) ? $args['meta'] : array();
+            $this->items        = is_array( $args['items'] ) ? $args['items'] : array();
+            $this->billing      = array(
+                'company'    => $args['billing_company'],
+                'first_name' => $args['billing_first_name'],
+                'last_name'  => $args['billing_last_name'],
+                'email'      => $args['billing_email'],
+                'phone'      => $args['billing_phone'],
+                'address_1'  => $args['billing_address_1'],
+                'address_2'  => $args['billing_address_2'],
+                'country'    => $args['billing_country'],
+            );
+            $this->order_number = (string) $args['order_number'];
+        }
+
+        public function get_id() {
+            return $this->id;
+        }
+
+        public function get_total() {
+            return $this->total;
+        }
+
+        public function get_meta( $key, $single = true ) {
+            if ( isset( $this->meta[ $key ] ) ) {
+                return $this->meta[ $key ];
+            }
+
+            return $single ? '' : array();
+        }
+
+        public function update_meta_data( $key, $value ) {
+            $this->meta[ $key ] = $value;
+        }
+
+        public function save() {
+            // No-op for tests.
+        }
+
+        public function add_order_note( $note ) {
+            $this->notes[] = $note;
+        }
+
+        public function get_notes() {
+            return $this->notes;
+        }
+
+        public function get_items( $type = 'line_item' ) {
+            return $this->items;
+        }
+
+        public function set_items( array $items ) {
+            $this->items = $items;
+        }
+
+        public function get_billing_company() {
+            return $this->billing['company'];
+        }
+
+        public function get_billing_first_name() {
+            return $this->billing['first_name'];
+        }
+
+        public function get_billing_last_name() {
+            return $this->billing['last_name'];
+        }
+
+        public function get_billing_email() {
+            return $this->billing['email'];
+        }
+
+        public function get_billing_phone() {
+            return $this->billing['phone'];
+        }
+
+        public function get_billing_address_1() {
+            return $this->billing['address_1'];
+        }
+
+        public function get_billing_address_2() {
+            return $this->billing['address_2'];
+        }
+
+        public function get_billing_country() {
+            return $this->billing['country'];
+        }
+
+        public function get_shipping_total() {
+            return 0;
+        }
+
+        public function get_shipping_tax() {
+            return 0;
+        }
+
+        public function get_payment_method() {
+            return 'cod';
+        }
+
+        public function get_order_number() {
+            return '' !== $this->order_number ? $this->order_number : (string) $this->id;
+        }
+    }
+}

--- a/tests/stubs/class-wc-product.php
+++ b/tests/stubs/class-wc-product.php
@@ -1,0 +1,61 @@
+<?php
+if ( ! class_exists( 'WC_Product' ) ) {
+    class WC_Product {
+        protected $id;
+        protected $parent_id;
+        protected $meta = array();
+        protected $regular_price = '';
+
+        public function __construct( array $args = array() ) {
+            $defaults = array(
+                'id'            => 0,
+                'parent_id'     => 0,
+                'meta'          => array(),
+                'regular_price' => '',
+            );
+
+            $args = array_merge( $defaults, $args );
+
+            $this->id            = (int) $args['id'];
+            $this->parent_id     = (int) $args['parent_id'];
+            $this->meta          = is_array( $args['meta'] ) ? $args['meta'] : array();
+            $this->regular_price = (string) $args['regular_price'];
+        }
+
+        public function get_id() {
+            return $this->id;
+        }
+
+        public function get_parent_id() {
+            return $this->parent_id;
+        }
+
+        public function get_meta( $key, $single = true ) {
+            if ( isset( $this->meta[ $key ] ) ) {
+                return $this->meta[ $key ];
+            }
+
+            return $single ? '' : array();
+        }
+
+        public function set_meta( $key, $value ) {
+            $this->meta[ $key ] = $value;
+        }
+
+        public function get_regular_price() {
+            return $this->regular_price;
+        }
+
+        public function set_regular_price( $price ) {
+            $this->regular_price = (string) $price;
+        }
+
+        public function save() {
+            // No-op for tests.
+        }
+
+        public function get_sku() {
+            return isset( $this->meta['_sku'] ) ? $this->meta['_sku'] : '';
+        }
+    }
+}

--- a/wp-content/plugins/contifico-woocommerce/admin/class-settings.php
+++ b/wp-content/plugins/contifico-woocommerce/admin/class-settings.php
@@ -36,6 +36,7 @@ class Contifico_WooCommerce_Admin_Settings {
     public function init() {
         add_action( 'admin_menu', array( $this, 'register_menu' ) );
         add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'admin_post_contifico_download_api_log', array( $this, 'handle_api_log_download' ) );
     }
 
     /**
@@ -115,6 +116,18 @@ class Contifico_WooCommerce_Admin_Settings {
         );
 
         add_settings_field(
+            'contifico_woocommerce_api_logging',
+            __( 'Registro de solicitudes', 'contifico-woocommerce' ),
+            array( $this, 'render_api_logging_field' ),
+            $this->option_group,
+            'contifico_woocommerce_api',
+            array(
+                'label_for'  => 'contifico_woocommerce_api_logging',
+                'option_key' => 'api_logging_enabled',
+            )
+        );
+
+        add_settings_field(
             'contifico_woocommerce_warehouse',
             __( 'Bodega o punto de emisión', 'contifico-woocommerce' ),
             array( $this, 'render_text_field' ),
@@ -143,6 +156,52 @@ class Contifico_WooCommerce_Admin_Settings {
             'contifico_woocommerce_sync'
         );
 
+        add_settings_field(
+            'contifico_woocommerce_sync_interval',
+            __( 'Frecuencia automática', 'contifico-woocommerce' ),
+            array( $this, 'render_select_field' ),
+            $this->option_group,
+            'contifico_woocommerce_sync',
+            array(
+                'label_for'   => 'contifico_woocommerce_sync_interval',
+                'option_key'  => 'inventory_sync_interval',
+                'options'     => $this->get_inventory_interval_options(),
+                'description' => __( 'Define cada cuánto se consultará el inventario desde Contifico.', 'contifico-woocommerce' ),
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_sync_batch_size',
+            __( 'Tamaño del lote', 'contifico-woocommerce' ),
+            array( $this, 'render_text_field' ),
+            $this->option_group,
+            'contifico_woocommerce_sync',
+            array(
+                'label_for'   => 'contifico_woocommerce_sync_batch_size',
+                'option_key'  => 'inventory_batch_size',
+                'type'        => 'number',
+                'description' => __( 'Número de productos que se procesarán en cada lote cuando Action Scheduler esté disponible.', 'contifico-woocommerce' ),
+                'attributes'  => array(
+                    'min'  => 10,
+                    'step' => 10,
+                ),
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_sync_price_list',
+            __( 'Lista de precios a usar', 'contifico-woocommerce' ),
+            array( $this, 'render_select_field' ),
+            $this->option_group,
+            'contifico_woocommerce_sync',
+            array(
+                'label_for'   => 'contifico_woocommerce_sync_price_list',
+                'option_key'  => 'inventory_price_list',
+                'options'     => $this->get_price_list_options(),
+                'description' => __( 'Selecciona qué lista PVP actualizará el precio regular en WooCommerce durante la sincronización.', 'contifico-woocommerce' ),
+            )
+        );
+
         add_settings_section(
             'contifico_woocommerce_inventory',
             __( 'Sincronización de inventario', 'contifico-woocommerce' ),
@@ -156,6 +215,77 @@ class Contifico_WooCommerce_Admin_Settings {
             array( $this, 'render_inventory_tools_field' ),
             $this->option_group,
             'contifico_woocommerce_inventory'
+        );
+
+        add_settings_section(
+            'contifico_woocommerce_inventory_transfer',
+            __( 'Movimientos entre bodegas', 'contifico-woocommerce' ),
+            '__return_false',
+            $this->option_group
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_transfer_enabled',
+            __( 'Transferencias automáticas', 'contifico-woocommerce' ),
+            array( $this, 'render_checkbox_field' ),
+            $this->option_group,
+            'contifico_woocommerce_inventory_transfer',
+            array(
+                'label_for'  => 'contifico_woocommerce_transfer_enabled',
+                'option_key' => 'inventory_transfer_enabled',
+                'label'      => __( 'Mover stock entre bodegas al cambiar el estado del pedido.', 'contifico-woocommerce' ),
+                'description'=> __( 'Traslada unidades entre la bodega física y la bodega web cuando el pedido avanza o se revierte.', 'contifico-woocommerce' ),
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_transfer_source',
+            __( 'Bodega origen', 'contifico-woocommerce' ),
+            array( $this, 'render_text_field' ),
+            $this->option_group,
+            'contifico_woocommerce_inventory_transfer',
+            array(
+                'label_for'   => 'contifico_woocommerce_transfer_source',
+                'option_key'  => 'inventory_transfer_source',
+                'description' => __( 'Identificador de la bodega desde la cual se descontará el stock.', 'contifico-woocommerce' ),
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_transfer_destination',
+            __( 'Bodega destino', 'contifico-woocommerce' ),
+            array( $this, 'render_text_field' ),
+            $this->option_group,
+            'contifico_woocommerce_inventory_transfer',
+            array(
+                'label_for'   => 'contifico_woocommerce_transfer_destination',
+                'option_key'  => 'inventory_transfer_destination',
+                'description' => __( 'Identificador de la bodega que recibirá el stock reservado para la tienda en línea.', 'contifico-woocommerce' ),
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_transfer_decrease_statuses',
+            __( 'Estados que reservan stock', 'contifico-woocommerce' ),
+            array( $this, 'render_statuses_field_custom' ),
+            $this->option_group,
+            'contifico_woocommerce_inventory_transfer',
+            array(
+                'option_key' => 'inventory_transfer_decrease_statuses',
+                'description'=> __( 'Cuando el pedido alcance alguno de estos estados se moverá stock desde la bodega origen a la bodega destino.', 'contifico-woocommerce' ),
+            )
+        );
+
+        add_settings_field(
+            'contifico_woocommerce_transfer_restore_statuses',
+            __( 'Estados que devuelven stock', 'contifico-woocommerce' ),
+            array( $this, 'render_statuses_field_custom' ),
+            $this->option_group,
+            'contifico_woocommerce_inventory_transfer',
+            array(
+                'option_key' => 'inventory_transfer_restore_statuses',
+                'description'=> __( 'Cuando el pedido regrese a alguno de estos estados se revertirá el movimiento de inventario.', 'contifico-woocommerce' ),
+            )
         );
 
         add_settings_section(
@@ -431,20 +561,34 @@ class Contifico_WooCommerce_Admin_Settings {
             'type'        => 'text',
             'placeholder' => '',
             'description' => '',
+            'attributes'  => array(),
         );
 
         $args     = wp_parse_args( $args, $defaults );
         $settings = $this->get_settings();
         $value    = isset( $settings[ $args['option_key'] ] ) ? $settings[ $args['option_key'] ] : '';
 
+        $attributes = '';
+
+        if ( ! empty( $args['attributes'] ) && is_array( $args['attributes'] ) ) {
+            foreach ( $args['attributes'] as $attr_key => $attr_value ) {
+                if ( '' === $attr_key ) {
+                    continue;
+                }
+
+                $attributes .= sprintf( ' %s="%s"', esc_attr( $attr_key ), esc_attr( $attr_value ) );
+            }
+        }
+
         printf(
-            '<input type="%1$s" id="%2$s" name="%3$s[%4$s]" value="%5$s" class="regular-text" placeholder="%6$s" />',
+            '<input type="%1$s" id="%2$s" name="%3$s[%4$s]" value="%5$s" class="regular-text" placeholder="%6$s"%7$s />',
             esc_attr( $args['type'] ),
             esc_attr( $args['label_for'] ),
             esc_attr( $this->option_name ),
             esc_attr( $args['option_key'] ),
             esc_attr( $value ),
-            esc_attr( $args['placeholder'] )
+            esc_attr( $args['placeholder'] ),
+            $attributes
         );
 
         if ( ! empty( $args['description'] ) ) {
@@ -552,13 +696,118 @@ class Contifico_WooCommerce_Admin_Settings {
     }
 
     /**
+     * Renderiza el campo de activación del log de la API y el acceso al archivo.
+     *
+     * @param array $args Argumentos del campo.
+     *
+     * @return void
+     */
+    public function render_api_logging_field( $args ) {
+        $args = wp_parse_args(
+            $args,
+            array(
+                'label_for'  => 'contifico_woocommerce_api_logging',
+                'option_key' => 'api_logging_enabled',
+            )
+        );
+
+        $settings = $this->get_settings();
+        $enabled  = isset( $settings[ $args['option_key'] ] ) && 'yes' === $settings[ $args['option_key'] ];
+
+        printf(
+            '<label><input type="checkbox" id="%1$s" name="%2$s[%3$s]" value="yes" %4$s /> %5$s</label>',
+            esc_attr( $args['label_for'] ),
+            esc_attr( $this->option_name ),
+            esc_attr( $args['option_key'] ),
+            checked( $enabled, true, false ),
+            esc_html__( 'Guardar un registro detallado de las solicitudes a la API de Contifico.', 'contifico-woocommerce' )
+        );
+
+        $description = __( 'Activa esta opción sólo cuando necesites diagnosticar problemas de conexión.', 'contifico-woocommerce' );
+        printf( '<p class="description">%s</p>', esc_html( $description ) );
+
+        if ( ! class_exists( 'Contifico_WooCommerce_Api_Contifico_Client' ) ) {
+            return;
+        }
+
+        $log_path = Contifico_WooCommerce_Api_Contifico_Client::get_log_file_path();
+
+        if ( ! $enabled ) {
+            if ( $log_path && file_exists( $log_path ) ) {
+                printf(
+                    '<p class="description">%s</p>',
+                    esc_html__( 'El archivo existente se conservará aunque el registro esté desactivado.', 'contifico-woocommerce' )
+                );
+            }
+
+            return;
+        }
+
+        if ( ! $log_path || ! file_exists( $log_path ) ) {
+            echo '<p class="description">' . esc_html__( 'Aún no se ha generado ningún archivo de registro.', 'contifico-woocommerce' ) . '</p>';
+            return;
+        }
+
+        $url  = wp_nonce_url( admin_url( 'admin-post.php?action=contifico_download_api_log' ), 'contifico_download_api_log' );
+        $size = function_exists( 'size_format' ) ? size_format( filesize( $log_path ) ) : round( filesize( $log_path ) / 1024, 2 ) . ' KB';
+
+        printf(
+            '<p><a href="%1$s" class="button">%2$s</a> <span class="description">%3$s</span></p>',
+            esc_url( $url ),
+            esc_html__( 'Descargar registro', 'contifico-woocommerce' ),
+            sprintf(
+                /* translators: 1: log file path, 2: formatted file size */
+                esc_html__( 'Archivo actual: %1$s (%2$s).', 'contifico-woocommerce' ),
+                esc_html( $log_path ),
+                esc_html( $size )
+            )
+        );
+    }
+
+    /**
      * Renderiza los checkboxes para seleccionar los estados que se sincronizarán.
      *
      * @return void
      */
     public function render_statuses_field() {
+        $this->render_status_checkboxes( 'sync_statuses' );
+    }
+
+    /**
+     * Renderiza un grupo de checkboxes reutilizable para listas de estados.
+     *
+     * @param array $args Argumentos del campo.
+     *
+     * @return void
+     */
+    public function render_statuses_field_custom( $args ) {
+        $args = wp_parse_args(
+            $args,
+            array(
+                'option_key'  => '',
+                'description' => '',
+            )
+        );
+
+        if ( '' === $args['option_key'] ) {
+            echo '<p>' . esc_html__( 'No se pudo cargar la lista de estados de pedido.', 'contifico-woocommerce' ) . '</p>';
+            return;
+        }
+
+        $this->render_status_checkboxes( $args['option_key'], $args['description'] );
+    }
+
+    /**
+     * Imprime los checkboxes asociados a un option determinado.
+     *
+     * @param string $option_key  Clave dentro del arreglo de ajustes.
+     * @param string $description Texto opcional que se mostrará bajo la lista.
+     *
+     * @return void
+     */
+    protected function render_status_checkboxes( $option_key, $description = '' ) {
         $settings = $this->get_settings();
-        $current  = isset( $settings['sync_statuses'] ) && is_array( $settings['sync_statuses'] ) ? $settings['sync_statuses'] : array();
+        $current  = isset( $settings[ $option_key ] ) && is_array( $settings[ $option_key ] ) ? $settings[ $option_key ] : array();
         $statuses = function_exists( 'wc_get_order_statuses' ) ? wc_get_order_statuses() : array();
 
         if ( empty( $statuses ) ) {
@@ -568,13 +817,47 @@ class Contifico_WooCommerce_Admin_Settings {
 
         foreach ( $statuses as $status_key => $status_label ) {
             printf(
-                '<label><input type="checkbox" name="%1$s[sync_statuses][]" value="%2$s" %3$s /> %4$s</label><br />',
+                '<label><input type="checkbox" name="%1$s[%2$s][]" value="%3$s" %4$s /> %5$s</label><br />',
                 esc_attr( $this->option_name ),
+                esc_attr( $option_key ),
                 esc_attr( $status_key ),
                 checked( in_array( $status_key, $current, true ), true, false ),
                 esc_html( $status_label )
             );
         }
+
+        if ( '' !== $description ) {
+            printf( '<p class="description">%s</p>', esc_html( $description ) );
+        }
+    }
+
+    /**
+     * Devuelve las opciones disponibles para el intervalo de sincronización automática.
+     *
+     * @return array
+     */
+    protected function get_inventory_interval_options() {
+        return array(
+            'manual'     => __( 'Manual (no programar)', 'contifico-woocommerce' ),
+            '15min'      => __( 'Cada 15 minutos', 'contifico-woocommerce' ),
+            'hourly'     => __( 'Cada hora', 'contifico-woocommerce' ),
+            'twicedaily' => __( 'Dos veces al día', 'contifico-woocommerce' ),
+            'daily'      => __( 'Diario', 'contifico-woocommerce' ),
+        );
+    }
+
+    /**
+     * Devuelve las listas de precio disponibles para sincronizar.
+     *
+     * @return array
+     */
+    protected function get_price_list_options() {
+        return array(
+            'none' => __( 'No actualizar precios', 'contifico-woocommerce' ),
+            'pvp1' => __( 'PVP1', 'contifico-woocommerce' ),
+            'pvp2' => __( 'PVP2', 'contifico-woocommerce' ),
+            'pvp3' => __( 'PVP3', 'contifico-woocommerce' ),
+        );
     }
 
     /**
@@ -591,6 +874,15 @@ class Contifico_WooCommerce_Admin_Settings {
             'api_secret'    => '',
             'warehouse'     => '',
             'sync_statuses' => array(),
+            'api_logging_enabled'             => '',
+            'inventory_sync_interval'         => 'hourly',
+            'inventory_batch_size'            => 100,
+            'inventory_price_list'            => 'none',
+            'inventory_transfer_enabled'      => '',
+            'inventory_transfer_source'       => '',
+            'inventory_transfer_destination'  => '',
+            'inventory_transfer_decrease_statuses' => array(),
+            'inventory_transfer_restore_statuses'  => array(),
             'invoice_enabled'                 => '',
             'invoice_trigger_status'          => '',
             'invoice_document_type'           => 'FAC',
@@ -620,6 +912,15 @@ class Contifico_WooCommerce_Admin_Settings {
             'api_secret'    => sanitize_text_field( $input['api_secret'] ),
             'warehouse'     => sanitize_text_field( $input['warehouse'] ),
             'sync_statuses' => array(),
+            'api_logging_enabled'             => ! empty( $input['api_logging_enabled'] ) ? 'yes' : 'no',
+            'inventory_sync_interval'         => $this->sanitize_inventory_interval( $input['inventory_sync_interval'] ),
+            'inventory_batch_size'            => $this->sanitize_batch_size( $input['inventory_batch_size'] ),
+            'inventory_price_list'            => $this->sanitize_price_list( $input['inventory_price_list'] ),
+            'inventory_transfer_enabled'      => ! empty( $input['inventory_transfer_enabled'] ) ? 'yes' : 'no',
+            'inventory_transfer_source'       => sanitize_text_field( $input['inventory_transfer_source'] ),
+            'inventory_transfer_destination'  => sanitize_text_field( $input['inventory_transfer_destination'] ),
+            'inventory_transfer_decrease_statuses' => array(),
+            'inventory_transfer_restore_statuses'  => array(),
             'invoice_enabled'                 => ! empty( $input['invoice_enabled'] ) ? 'yes' : 'no',
             'invoice_trigger_status'          => sanitize_text_field( $input['invoice_trigger_status'] ),
             'invoice_document_type'           => in_array( $input['invoice_document_type'], array( 'FAC', 'PRE', 'COT' ), true ) ? $input['invoice_document_type'] : 'FAC',
@@ -646,6 +947,15 @@ class Contifico_WooCommerce_Admin_Settings {
             $sanitized['sync_statuses'] = array_values( array_unique( $statuses ) );
         }
 
+        foreach ( array( 'inventory_transfer_decrease_statuses', 'inventory_transfer_restore_statuses' ) as $status_key ) {
+            if ( empty( $input[ $status_key ] ) || ! is_array( $input[ $status_key ] ) ) {
+                continue;
+            }
+
+            $values = array_map( 'sanitize_text_field', $input[ $status_key ] );
+            $sanitized[ $status_key ] = array_values( array_unique( $values ) );
+        }
+
         return $sanitized;
     }
 
@@ -661,6 +971,15 @@ class Contifico_WooCommerce_Admin_Settings {
             'api_secret'    => '',
             'warehouse'     => '',
             'sync_statuses' => array(),
+            'api_logging_enabled'             => 'no',
+            'inventory_sync_interval'         => 'hourly',
+            'inventory_batch_size'            => 100,
+            'inventory_price_list'            => 'none',
+            'inventory_transfer_enabled'      => 'no',
+            'inventory_transfer_source'       => '',
+            'inventory_transfer_destination'  => '',
+            'inventory_transfer_decrease_statuses' => array(),
+            'inventory_transfer_restore_statuses'  => array(),
             'invoice_enabled'                 => 'no',
             'invoice_trigger_status'          => '',
             'invoice_document_type'           => 'FAC',
@@ -685,6 +1004,59 @@ class Contifico_WooCommerce_Admin_Settings {
         $settings = get_option( $this->option_name, array() );
 
         return wp_parse_args( $settings, $defaults );
+    }
+
+    /**
+     * Limpia el valor recibido para el intervalo de sincronización.
+     *
+     * @param string $value Valor recibido desde el formulario.
+     *
+     * @return string
+     */
+    protected function sanitize_inventory_interval( $value ) {
+        $value   = is_string( $value ) ? $value : '';
+        $options = $this->get_inventory_interval_options();
+
+        if ( array_key_exists( $value, $options ) ) {
+            return $value;
+        }
+
+        return 'hourly';
+    }
+
+    /**
+     * Asegura que el tamaño del lote sea un entero positivo razonable.
+     *
+     * @param mixed $value Valor recibido desde el formulario.
+     *
+     * @return int
+     */
+    protected function sanitize_batch_size( $value ) {
+        $size = absint( $value );
+
+        if ( $size < 10 ) {
+            $size = 10;
+        }
+
+        return $size;
+    }
+
+    /**
+     * Limpia la lista de precios seleccionada.
+     *
+     * @param string $value Valor recibido.
+     *
+     * @return string
+     */
+    protected function sanitize_price_list( $value ) {
+        $value   = is_string( $value ) ? $value : '';
+        $options = $this->get_price_list_options();
+
+        if ( array_key_exists( $value, $options ) ) {
+            return $value;
+        }
+
+        return 'none';
     }
 
     /**
@@ -740,6 +1112,7 @@ class Contifico_WooCommerce_Admin_Settings {
         ?>
         <div class="wrap">
             <h1><?php esc_html_e( 'Integración con Contifico', 'contifico-woocommerce' ); ?></h1>
+            <?php $this->render_configuration_diagnostics(); ?>
             <form action="options.php" method="post">
                 <?php
                 settings_fields( $option_group );
@@ -850,6 +1223,185 @@ class Contifico_WooCommerce_Admin_Settings {
     }
 
     /**
+     * Muestra un resumen del estado de la configuración actual.
+     *
+     * @return void
+     */
+    protected function render_configuration_diagnostics() {
+        $items = $this->evaluate_configuration_status();
+
+        if ( empty( $items ) ) {
+            return;
+        }
+
+        echo '<div class="contifico-settings-diagnostics">';
+        echo '<h2>' . esc_html__( 'Diagnóstico rápido', 'contifico-woocommerce' ) . '</h2>';
+        echo '<ul>';
+
+        foreach ( $items as $item ) {
+            $label   = isset( $item['label'] ) ? $item['label'] : '';
+            $message = isset( $item['message'] ) ? $item['message'] : '';
+            $status  = isset( $item['status'] ) ? $item['status'] : 'info';
+            $section = isset( $item['section'] ) ? $item['section'] : '';
+
+            $class = 'status-' . sanitize_html_class( $status );
+
+            if ( '' !== $section ) {
+                $label_output = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $this->build_section_link( $section ) ), esc_html( $label ) );
+            } else {
+                $label_output = esc_html( $label );
+            }
+
+            printf(
+                '<li class="%1$s"><strong>%2$s</strong> %3$s</li>',
+                esc_attr( $class ),
+                $label_output,
+                esc_html( $message )
+            );
+        }
+
+        echo '</ul>';
+        echo '</div>';
+    }
+
+    /**
+     * Calcula el estado de cada bloque de configuración relevante.
+     *
+     * @return array
+     */
+    protected function evaluate_configuration_status() {
+        $settings = $this->get_settings();
+        $results  = array();
+
+        $api_ready = ! empty( $settings['api_url'] ) && ! empty( $settings['api_key'] ) && ! empty( $settings['api_secret'] );
+        $results[] = array(
+            'section' => 'contifico_woocommerce_api',
+            'label'   => __( 'Credenciales de API', 'contifico-woocommerce' ),
+            'status'  => $api_ready ? 'ok' : 'error',
+            'message' => $api_ready
+                ? __( 'Conexión configurada correctamente.', 'contifico-woocommerce' )
+                : __( 'Agrega la URL, el API Key y el API Secret para conectar con Contifico.', 'contifico-woocommerce' ),
+        );
+
+        $interval_options = $this->get_inventory_interval_options();
+        $interval_value   = isset( $settings['inventory_sync_interval'] ) ? $settings['inventory_sync_interval'] : 'hourly';
+        $interval_label   = isset( $interval_options[ $interval_value ] ) ? $interval_options[ $interval_value ] : $interval_options['hourly'];
+        $results[]        = array(
+            'section' => 'contifico_woocommerce_sync',
+            'label'   => __( 'Sincronización automática', 'contifico-woocommerce' ),
+            'status'  => 'manual' === $interval_value ? 'warning' : 'ok',
+            'message' => 'manual' === $interval_value
+                ? __( 'La sincronización automática está desactivada. Ejecuta los procesos manualmente cuando lo necesites.', 'contifico-woocommerce' )
+                : sprintf( __( 'Se ejecutará %s.', 'contifico-woocommerce' ), $interval_label ),
+        );
+
+        $price_list = isset( $settings['inventory_price_list'] ) ? $settings['inventory_price_list'] : 'none';
+        $price_map  = $this->get_price_list_options();
+        $results[]  = array(
+            'section' => 'contifico_woocommerce_sync',
+            'label'   => __( 'Lista de precios', 'contifico-woocommerce' ),
+            'status'  => 'none' === $price_list ? 'warning' : 'ok',
+            'message' => 'none' === $price_list
+                ? __( 'Los precios de WooCommerce no se actualizarán automáticamente.', 'contifico-woocommerce' )
+                : sprintf( __( 'Sincronizando precios con %s.', 'contifico-woocommerce' ), isset( $price_map[ $price_list ] ) ? $price_map[ $price_list ] : strtoupper( $price_list ) ),
+        );
+
+        $transfer_enabled = isset( $settings['inventory_transfer_enabled'] ) && 'yes' === $settings['inventory_transfer_enabled'];
+        if ( $transfer_enabled ) {
+            $source      = isset( $settings['inventory_transfer_source'] ) ? $settings['inventory_transfer_source'] : '';
+            $destination = isset( $settings['inventory_transfer_destination'] ) ? $settings['inventory_transfer_destination'] : '';
+            $decrease    = isset( $settings['inventory_transfer_decrease_statuses'] ) ? $settings['inventory_transfer_decrease_statuses'] : array();
+            $restore     = isset( $settings['inventory_transfer_restore_statuses'] ) ? $settings['inventory_transfer_restore_statuses'] : array();
+
+            if ( '' === $source || '' === $destination ) {
+                $results[] = array(
+                    'section' => 'contifico_woocommerce_inventory_transfer',
+                    'label'   => __( 'Transferencias de inventario', 'contifico-woocommerce' ),
+                    'status'  => 'error',
+                    'message' => __( 'Define las bodegas de origen y destino para automatizar los movimientos.', 'contifico-woocommerce' ),
+                );
+            } elseif ( empty( $decrease ) || empty( $restore ) ) {
+                $results[] = array(
+                    'section' => 'contifico_woocommerce_inventory_transfer',
+                    'label'   => __( 'Transferencias de inventario', 'contifico-woocommerce' ),
+                    'status'  => 'warning',
+                    'message' => __( 'Selecciona los estados que reservan y devuelven stock para completar la configuración.', 'contifico-woocommerce' ),
+                );
+            } else {
+                $results[] = array(
+                    'section' => 'contifico_woocommerce_inventory_transfer',
+                    'label'   => __( 'Transferencias de inventario', 'contifico-woocommerce' ),
+                    'status'  => 'ok',
+                    'message' => __( 'Los movimientos automáticos entre bodegas están activos.', 'contifico-woocommerce' ),
+                );
+            }
+        } else {
+            $results[] = array(
+                'section' => 'contifico_woocommerce_inventory_transfer',
+                'label'   => __( 'Transferencias de inventario', 'contifico-woocommerce' ),
+                'status'  => 'info',
+                'message' => __( 'Las transferencias automáticas están desactivadas.', 'contifico-woocommerce' ),
+            );
+        }
+
+        $invoice_enabled = isset( $settings['invoice_enabled'] ) && 'yes' === $settings['invoice_enabled'];
+        if ( $invoice_enabled ) {
+            $required = array(
+                $settings['invoice_trigger_status'],
+                $settings['invoice_sender_tax_id'],
+                $settings['invoice_sender_name'],
+                $settings['invoice_sender_email'],
+                $settings['invoice_sender_address'],
+            );
+
+            $environment = isset( $settings['invoice_environment'] ) ? $settings['invoice_environment'] : 'test';
+            $env_fields  = array(
+                $settings[ 'invoice_' . $environment . '_pos_token' ],
+                $settings[ 'invoice_' . $environment . '_establishment' ],
+                $settings[ 'invoice_' . $environment . '_emission_point' ],
+                $settings[ 'invoice_' . $environment . '_next_number' ],
+            );
+
+            $all_fields = array_merge( $required, $env_fields );
+
+            $results[] = array(
+                'section' => 'contifico_woocommerce_invoicing',
+                'label'   => __( 'Facturación electrónica', 'contifico-woocommerce' ),
+                'status'  => in_array( '', $all_fields, true ) ? 'error' : 'ok',
+                'message' => in_array( '', $all_fields, true )
+                    ? __( 'Completa los campos obligatorios para emitir documentos electrónicos.', 'contifico-woocommerce' )
+                    : __( 'La emisión automática de documentos está lista.', 'contifico-woocommerce' ),
+            );
+        } else {
+            $results[] = array(
+                'section' => 'contifico_woocommerce_invoicing',
+                'label'   => __( 'Facturación electrónica', 'contifico-woocommerce' ),
+                'status'  => 'info',
+                'message' => __( 'La generación automática de documentos está desactivada.', 'contifico-woocommerce' ),
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Calcula el enlace hacia una sección específica dentro de la página.
+     *
+     * @param string $section_id Identificador de la sección.
+     *
+     * @return string
+     */
+    protected function build_section_link( $section_id ) {
+        $section_id = sanitize_key( $section_id );
+
+        if ( '' === $section_id ) {
+            return '#';
+        }
+
+        return '#' . $section_id;
+    }
+
+    /**
      * Muestra un aviso contextual después de ejecutar la sincronización manual.
      *
      * @return void
@@ -882,5 +1434,41 @@ class Contifico_WooCommerce_Admin_Settings {
             esc_attr( $class ),
             esc_html( $notice['message'] )
         );
+    }
+
+    /**
+     * Permite descargar el archivo de log generado por la API.
+     *
+     * @return void
+     */
+    public function handle_api_log_download() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            wp_die( esc_html__( 'No tienes permisos para realizar esta acción.', 'contifico-woocommerce' ) );
+        }
+
+        check_admin_referer( 'contifico_download_api_log' );
+
+        if ( ! class_exists( 'Contifico_WooCommerce_Api_Contifico_Client' ) ) {
+            wp_die( esc_html__( 'El registro solicitado no está disponible.', 'contifico-woocommerce' ) );
+        }
+
+        $path = Contifico_WooCommerce_Api_Contifico_Client::get_log_file_path();
+
+        if ( ! $path || ! file_exists( $path ) ) {
+            wp_die( esc_html__( 'No se encontró el archivo de registro.', 'contifico-woocommerce' ) );
+        }
+
+        if ( ! is_readable( $path ) ) {
+            wp_die( esc_html__( 'El archivo de registro no se puede leer en el servidor.', 'contifico-woocommerce' ) );
+        }
+
+        nocache_headers();
+
+        header( 'Content-Type: text/plain' );
+        header( 'Content-Disposition: attachment; filename=' . basename( $path ) );
+        header( 'Content-Length: ' . filesize( $path ) );
+
+        readfile( $path );
+        exit;
     }
 }

--- a/wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/api/class-contifico-client.php
@@ -271,6 +271,138 @@ class Contifico_WooCommerce_Api_Contifico_Client {
     }
 
     /**
+     * Registra una transferencia de inventario entre bodegas.
+     *
+     * @param array $movement Datos del movimiento a crear.
+     *
+     * @return array|WP_Error
+     */
+    public function create_inventory_transfer( array $movement ) {
+        $normalized = $this->prepare_inventory_transfer_payload( $movement );
+
+        if ( is_wp_error( $normalized ) ) {
+            return $normalized;
+        }
+
+        $this->log(
+            'info',
+            'Enviando transferencia de inventario a Contifico.',
+            array(
+                'source'      => $normalized['bodega_id'],
+                'destination' => $normalized['bodega_destino_id'],
+                'lines'       => count( $normalized['detalles'] ),
+            )
+        );
+
+        $response = $this->request(
+            'POST',
+            '/movimiento-inventario/',
+            array(
+                'body' => $normalized,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $this->log(
+            'info',
+            'Transferencia de inventario registrada correctamente en Contifico.',
+            array(
+                'source'      => $normalized['bodega_id'],
+                'destination' => $normalized['bodega_destino_id'],
+                'lines'       => count( $normalized['detalles'] ),
+            )
+        );
+
+        return $response;
+    }
+
+    /**
+     * Normaliza el payload recibido para crear una transferencia de inventario.
+     *
+     * @param array $movement Movimiento recibido externamente.
+     *
+     * @return array|WP_Error
+     */
+    protected function prepare_inventory_transfer_payload( array $movement ) {
+        if ( empty( $movement['detalles'] ) || ! is_array( $movement['detalles'] ) ) {
+            return $this->create_wp_error(
+                'contifico_invalid_transfer_details',
+                $this->translate( 'Debes incluir al menos un producto para registrar la transferencia de inventario.' )
+            );
+        }
+
+        $details = array();
+
+        foreach ( $movement['detalles'] as $detail ) {
+            if ( ! is_array( $detail ) || empty( $detail['producto_id'] ) ) {
+                continue;
+            }
+
+            $quantity = isset( $detail['cantidad'] ) ? $detail['cantidad'] : null;
+
+            if ( null === $quantity ) {
+                continue;
+            }
+
+            if ( function_exists( 'wc_stock_amount' ) ) {
+                $quantity = wc_stock_amount( $quantity );
+            } else {
+                $quantity = (float) $quantity;
+            }
+
+            if ( $quantity <= 0 ) {
+                continue;
+            }
+
+            $entry = array(
+                'producto_id' => (string) $detail['producto_id'],
+                'cantidad'    => $quantity,
+            );
+
+            if ( isset( $detail['precio'] ) && '' !== $detail['precio'] ) {
+                $entry['precio'] = $detail['precio'];
+            }
+
+            $details[] = $entry;
+        }
+
+        if ( empty( $details ) ) {
+            return $this->create_wp_error(
+                'contifico_invalid_transfer_details',
+                $this->translate( 'Debes incluir al menos un producto para registrar la transferencia de inventario.' )
+            );
+        }
+
+        if ( empty( $movement['bodega_id'] ) || empty( $movement['bodega_destino_id'] ) ) {
+            return $this->create_wp_error(
+                'contifico_missing_transfer_warehouse',
+                $this->translate( 'Debes especificar la bodega de origen y destino para registrar la transferencia.' )
+            );
+        }
+
+        $movement['detalles']          = array_values( $details );
+        $movement['bodega_id']         = (string) $movement['bodega_id'];
+        $movement['bodega_destino_id'] = (string) $movement['bodega_destino_id'];
+
+        if ( empty( $movement['fecha'] ) ) {
+            $movement['fecha'] = function_exists( 'gmdate' ) ? gmdate( 'd/m/Y' ) : date( 'd/m/Y' );
+        }
+
+        if ( empty( $movement['tipo'] ) ) {
+            $movement['tipo'] = 'TRA';
+        }
+
+        if ( isset( $movement['descripcion'] ) ) {
+            $movement['descripcion'] = (string) $movement['descripcion'];
+        }
+
+        return $movement;
+    }
+
+    /**
      * Realiza la solicitud HTTP principal contra la API de Contifico.
      *
      * @param string $method   Método HTTP (GET, POST, PUT, ...).
@@ -329,6 +461,17 @@ class Contifico_WooCommerce_Api_Contifico_Client {
             }
         }
 
+        $this->log(
+            'debug',
+            __( 'Enviando solicitud a Contifico.', 'contifico-woocommerce' ),
+            array(
+                'method' => $method,
+                'url'    => $url,
+                'query'  => $options['query'],
+                'body'   => isset( $request_args['body'] ) ? $request_args['body'] : '',
+            )
+        );
+
         $attempt     = 0;
         $max_attempts = max( 1, (int) $options['retries'] + 1 );
         $last_error  = null;
@@ -352,6 +495,13 @@ class Contifico_WooCommerce_Api_Contifico_Client {
             $status_code = (int) wp_remote_retrieve_response_code( $response );
 
             if ( $status_code >= 200 && $status_code < 300 ) {
+                $this->log(
+                    'debug',
+                    __( 'Respuesta recibida de Contifico.', 'contifico-woocommerce' ),
+                    array(
+                        'status_code' => $status_code,
+                    )
+                );
                 return $this->handle_success_response( $response );
             }
 
@@ -614,6 +764,16 @@ class Contifico_WooCommerce_Api_Contifico_Client {
      * @return void
      */
     protected function log( $level, $message, array $context = array() ) {
+        if ( ! $this->should_log_level( $level ) ) {
+            return;
+        }
+
+        $normalized_context = array();
+
+        foreach ( $context as $key => $value ) {
+            $normalized_context[ $key ] = $this->stringify_for_log( $value );
+        }
+
         $logger = $this->get_logger();
 
         if ( $logger ) {
@@ -622,7 +782,7 @@ class Contifico_WooCommerce_Api_Contifico_Client {
                 $message,
                 array_merge(
                     array( 'source' => self::LOG_SOURCE ),
-                    $context
+                    $normalized_context
                 )
             );
             return;
@@ -630,14 +790,32 @@ class Contifico_WooCommerce_Api_Contifico_Client {
 
         $context_output = '';
 
-        if ( ! empty( $context ) ) {
-            $encoded = $this->json_encode( $context );
+        if ( ! empty( $normalized_context ) ) {
+            $encoded = $this->json_encode( $normalized_context );
             if ( false !== $encoded ) {
                 $context_output = ' ' . $encoded;
             }
         }
 
         error_log( sprintf( '[%s] %s%s', strtoupper( $level ), $message, $context_output ) );
+    }
+
+    /**
+     * Determina si la configuración permite registrar el evento.
+     *
+     * @param string $level Nivel solicitado.
+     *
+     * @return bool
+     */
+    protected function should_log_level( $level ) {
+        $level            = strtolower( (string) $level );
+        $critical_levels  = array( 'emergency', 'alert', 'critical', 'error' );
+
+        if ( in_array( $level, $critical_levels, true ) ) {
+            return true;
+        }
+
+        return $this->is_logging_enabled();
     }
 
     /**
@@ -655,6 +833,73 @@ class Contifico_WooCommerce_Api_Contifico_Client {
         }
 
         return $this->logger;
+    }
+
+    /**
+     * Verifica si el registro detallado está activo en los ajustes.
+     *
+     * @return bool
+     */
+    protected function is_logging_enabled() {
+        $settings = $this->get_settings();
+
+        return isset( $settings['api_logging_enabled'] ) && 'yes' === $settings['api_logging_enabled'];
+    }
+
+    /**
+     * Devuelve una representación segura para volcar en el log.
+     *
+     * @param mixed $value Valor original.
+     *
+     * @return string
+     */
+    protected function stringify_for_log( $value ) {
+        if ( is_bool( $value ) ) {
+            $value = $value ? 'true' : 'false';
+        }
+
+        if ( is_scalar( $value ) || null === $value ) {
+            return $this->truncate_log_value( (string) $value );
+        }
+
+        if ( is_array( $value ) || is_object( $value ) ) {
+            $encoded = $this->json_encode( $value );
+
+            if ( false !== $encoded ) {
+                return $this->truncate_log_value( $encoded );
+            }
+
+            if ( function_exists( 'print_r' ) ) {
+                return $this->truncate_log_value( print_r( $value, true ) );
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Corta un valor para evitar saturar el archivo de log.
+     *
+     * @param string $value Texto original.
+     *
+     * @return string
+     */
+    protected function truncate_log_value( $value ) {
+        $max_length = (int) apply_filters( 'contifico_woocommerce_log_value_length', 2000 );
+
+        if ( function_exists( 'mb_strlen' ) ) {
+            if ( mb_strlen( $value ) > $max_length ) {
+                return mb_substr( $value, 0, $max_length ) . '…';
+            }
+
+            return $value;
+        }
+
+        if ( strlen( $value ) > $max_length ) {
+            return substr( $value, 0, $max_length ) . '…';
+        }
+
+        return $value;
     }
 
     /**
@@ -702,13 +947,27 @@ class Contifico_WooCommerce_Api_Contifico_Client {
      */
     protected function prepare_settings( array $settings ) {
         $defaults = array(
-            'api_url'    => '',
-            'api_key'    => '',
-            'api_secret' => '',
-            'warehouse'  => '',
+            'api_url'             => '',
+            'api_key'             => '',
+            'api_secret'          => '',
+            'warehouse'           => '',
+            'api_logging_enabled' => 'no',
         );
 
         return array_merge( $defaults, $settings );
+    }
+
+    /**
+     * Devuelve la ruta completa del archivo de log generado por WooCommerce.
+     *
+     * @return string
+     */
+    public static function get_log_file_path() {
+        if ( ! class_exists( 'WC_Log_Handler_File' ) ) {
+            return '';
+        }
+
+        return WC_Log_Handler_File::get_log_file_path( self::LOG_SOURCE );
     }
 
     /**

--- a/wp-content/plugins/contifico-woocommerce/includes/class-inventory-transfer-manager.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/class-inventory-transfer-manager.php
@@ -1,0 +1,460 @@
+<?php
+/**
+ * Gestiona los movimientos de stock entre bodegas al cambiar el estado de los pedidos.
+ *
+ * @package Contifico_WooCommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Contifico_WooCommerce_Inventory_Transfer_Manager {
+
+    /**
+     * Meta key donde se almacena el estado de los movimientos realizados para un pedido.
+     */
+    const META_KEY = '_contifico_inventory_transfer_state';
+
+    /**
+     * Gestor de ajustes del plugin.
+     *
+     * @var Contifico_WooCommerce_Admin_Settings
+     */
+    protected $settings_manager;
+
+    /**
+     * Cliente HTTP para comunicarse con Contifico.
+     *
+     * @var Contifico_WooCommerce_Api_Contifico_Client
+     */
+    protected $client;
+
+    /**
+     * Logger opcional utilizado para depurar eventos.
+     *
+     * @var WC_Logger|null
+     */
+    protected $logger;
+
+    /**
+     * Constructor.
+     *
+     * @param Contifico_WooCommerce_Admin_Settings       $settings Gestor de ajustes.
+     * @param Contifico_WooCommerce_Api_Contifico_Client $client   Cliente HTTP hacia Contifico.
+     * @param WC_Logger|null                             $logger   Logger opcional.
+     */
+    public function __construct( Contifico_WooCommerce_Admin_Settings $settings, Contifico_WooCommerce_Api_Contifico_Client $client, $logger = null ) {
+        $this->settings_manager = $settings;
+        $this->client           = $client;
+        $this->logger           = $logger;
+    }
+
+    /**
+     * Registra los hooks necesarios para escuchar cambios de estado.
+     *
+     * @return void
+     */
+    public function init_hooks() {
+        add_action( 'woocommerce_order_status_changed', array( $this, 'maybe_handle_status_change' ), 10, 4 );
+    }
+
+    /**
+     * Comprueba si el cambio de estado amerita ejecutar un movimiento de inventario.
+     *
+     * @param int       $order_id   Identificador del pedido.
+     * @param string    $old_status Estado anterior.
+     * @param string    $new_status Nuevo estado.
+     * @param WC_Order  $order      Instancia del pedido.
+     *
+     * @return void
+     */
+    public function maybe_handle_status_change( $order_id, $old_status, $new_status, $order = null ) {
+        if ( ! $order instanceof WC_Order ) {
+            $order = function_exists( 'wc_get_order' ) ? wc_get_order( $order_id ) : null;
+        }
+
+        if ( ! $order instanceof WC_Order ) {
+            return;
+        }
+
+        $settings = $this->get_transfer_settings();
+
+        if ( ! $settings['enabled'] ) {
+            return;
+        }
+
+        $normalized_status = $this->normalize_status_key( $new_status );
+
+        if ( in_array( $normalized_status, $settings['decrease_statuses'], true ) ) {
+            $this->reserve_stock_for_order( $order, $settings );
+            return;
+        }
+
+        if ( in_array( $normalized_status, $settings['restore_statuses'], true ) ) {
+            $this->restore_stock_for_order( $order, $settings );
+        }
+    }
+
+    /**
+     * Ejecuta la transferencia desde la bodega física hacia la bodega web.
+     *
+     * @param WC_Order $order    Pedido en cuestión.
+     * @param array    $settings Ajustes normalizados de la integración.
+     *
+     * @return void
+     */
+    protected function reserve_stock_for_order( WC_Order $order, array $settings ) {
+        $state = $this->get_transfer_state( $order );
+
+        if ( ! empty( $state['reserved'] ) ) {
+            $this->log( 'debug', 'El pedido ya tiene un movimiento de reserva registrado.', array( 'order_id' => $order->get_id() ) );
+            return;
+        }
+
+        $details = $this->build_transfer_details_from_order( $order );
+
+        if ( empty( $details ) ) {
+            $this->log( 'info', 'No se encontraron productos elegibles para transferir inventario.', array( 'order_id' => $order->get_id() ) );
+            return;
+        }
+
+        $payload = $this->build_transfer_payload( $order, $settings['source'], $settings['destination'], $details, 'reserve' );
+
+        $response = $this->client->create_inventory_transfer( $payload );
+
+        if ( is_wp_error( $response ) ) {
+            $message = sprintf( __( 'No se pudo reservar inventario en Contifico: %s', 'contifico-woocommerce' ), $response->get_error_message() );
+            $order->add_order_note( $message );
+            $this->log( 'error', $response->get_error_message(), array( 'order_id' => $order->get_id() ) );
+            return;
+        }
+
+        $state = array(
+            'reserved'        => true,
+            'items'           => $details,
+            'source'          => $settings['source'],
+            'destination'     => $settings['destination'],
+            'last_movement'   => 'reserve',
+            'last_reference'  => isset( $response['codigo'] ) ? (string) $response['codigo'] : '',
+            'updated_at_gmt'  => current_time( 'mysql', true ),
+        );
+
+        $order->update_meta_data( self::META_KEY, $state );
+        $order->save();
+
+        $note = __( 'Inventario reservado en la bodega web de Contifico.', 'contifico-woocommerce' );
+
+        if ( ! empty( $state['last_reference'] ) ) {
+            $note = sprintf( __( 'Inventario reservado en Contifico. Referencia: %s.', 'contifico-woocommerce' ), $state['last_reference'] );
+        }
+
+        $order->add_order_note( $note );
+    }
+
+    /**
+     * Revierte una transferencia previa devolviendo el stock a la bodega física.
+     *
+     * @param WC_Order $order    Pedido en cuestión.
+     * @param array    $settings Ajustes normalizados de la integración.
+     *
+     * @return void
+     */
+    protected function restore_stock_for_order( WC_Order $order, array $settings ) {
+        $state = $this->get_transfer_state( $order );
+
+        if ( empty( $state['reserved'] ) || empty( $state['items'] ) ) {
+            $this->log( 'debug', 'No existe una reserva previa para revertir.', array( 'order_id' => $order->get_id() ) );
+            return;
+        }
+
+        $source      = isset( $state['source'] ) ? $state['source'] : $settings['source'];
+        $destination = isset( $state['destination'] ) ? $state['destination'] : $settings['destination'];
+
+        $payload = $this->build_transfer_payload( $order, $destination, $source, $state['items'], 'restore' );
+
+        $response = $this->client->create_inventory_transfer( $payload );
+
+        if ( is_wp_error( $response ) ) {
+            $message = sprintf( __( 'No se pudo revertir la transferencia de inventario: %s', 'contifico-woocommerce' ), $response->get_error_message() );
+            $order->add_order_note( $message );
+            $this->log( 'error', $response->get_error_message(), array( 'order_id' => $order->get_id() ) );
+            return;
+        }
+
+        $state['reserved']       = false;
+        $state['items']          = array();
+        $state['last_movement']  = 'restore';
+        $state['last_reference'] = isset( $response['codigo'] ) ? (string) $response['codigo'] : '';
+        $state['updated_at_gmt'] = current_time( 'mysql', true );
+
+        $order->update_meta_data( self::META_KEY, $state );
+        $order->save();
+
+        $note = __( 'Inventario devuelto a la bodega principal en Contifico.', 'contifico-woocommerce' );
+
+        if ( ! empty( $state['last_reference'] ) ) {
+            $note = sprintf( __( 'Inventario restituido en Contifico. Referencia: %s.', 'contifico-woocommerce' ), $state['last_reference'] );
+        }
+
+        $order->add_order_note( $note );
+    }
+
+    /**
+     * Construye los detalles de productos a transferir en base a los artículos del pedido.
+     *
+     * @param WC_Order $order Pedido analizado.
+     *
+     * @return array
+     */
+    protected function build_transfer_details_from_order( WC_Order $order ) {
+        $items = $order->get_items();
+
+        if ( empty( $items ) ) {
+            return array();
+        }
+
+        $grouped = array();
+
+        foreach ( $items as $item ) {
+            if ( ! is_object( $item ) || ! method_exists( $item, 'get_product' ) ) {
+                continue;
+            }
+
+            $product = $item->get_product();
+
+            if ( ! $product ) {
+                continue;
+            }
+
+            $contifico_id = $this->get_contifico_product_id( $product );
+
+            if ( '' === $contifico_id ) {
+                $this->log( 'notice', 'Se omitió un producto sin identificador de Contifico durante la transferencia.', array( 'order_id' => $order->get_id() ) );
+                continue;
+            }
+
+            $quantity = $this->resolve_item_quantity( $item );
+
+            if ( $quantity <= 0 ) {
+                continue;
+            }
+
+            if ( isset( $grouped[ $contifico_id ] ) ) {
+                $grouped[ $contifico_id ]['cantidad'] += $quantity;
+            } else {
+                $grouped[ $contifico_id ] = array(
+                    'producto_id' => (string) $contifico_id,
+                    'cantidad'    => $quantity,
+                );
+            }
+        }
+
+        return array_values( $grouped );
+    }
+
+    /**
+     * Determina el identificador remoto del producto en Contifico.
+     *
+     * @param WC_Product $product Producto relacionado al pedido.
+     *
+     * @return string
+     */
+    protected function get_contifico_product_id( $product ) {
+        if ( $product && method_exists( $product, 'get_meta' ) ) {
+            $value = $product->get_meta( '_contifico_product_id', true );
+
+            if ( '' !== $value ) {
+                return (string) $value;
+            }
+        }
+
+        $ids = array();
+
+        if ( $product && method_exists( $product, 'get_id' ) ) {
+            $ids[] = $product->get_id();
+        }
+
+        if ( $product && method_exists( $product, 'get_parent_id' ) ) {
+            $parent = $product->get_parent_id();
+
+            if ( $parent ) {
+                $ids[] = $parent;
+            }
+        }
+
+        foreach ( $ids as $candidate ) {
+            $value = $this->get_post_meta_value( $candidate );
+
+            if ( '' !== $value ) {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Recupera el meta `_contifico_product_id` de la base de datos si la función está disponible.
+     *
+     * @param int $product_id Identificador del producto.
+     *
+     * @return string
+     */
+    protected function get_post_meta_value( $product_id ) {
+        if ( $product_id && function_exists( 'get_post_meta' ) ) {
+            $value = get_post_meta( $product_id, '_contifico_product_id', true );
+
+            if ( ! empty( $value ) ) {
+                return (string) $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Calcula la cantidad asociada al artículo del pedido.
+     *
+     * @param WC_Order_Item_Product $item Elemento del pedido.
+     *
+     * @return float
+     */
+    protected function resolve_item_quantity( $item ) {
+        $quantity = null;
+
+        if ( method_exists( $item, 'get_meta' ) ) {
+            $reduced = $item->get_meta( '_reduced_stock', true );
+
+            if ( '' !== $reduced ) {
+                $quantity = $reduced;
+            }
+        }
+
+        if ( null === $quantity && method_exists( $item, 'get_quantity' ) ) {
+            $quantity = $item->get_quantity();
+        }
+
+        if ( null === $quantity ) {
+            return 0;
+        }
+
+        if ( function_exists( 'wc_stock_amount' ) ) {
+            $quantity = wc_stock_amount( $quantity );
+        } else {
+            $quantity = (float) $quantity;
+        }
+
+        return $quantity > 0 ? (float) $quantity : 0;
+    }
+
+    /**
+     * Construye el payload que se enviará a Contifico.
+     *
+     * @param WC_Order $order            Pedido involucrado.
+     * @param string   $source           Bodega origen.
+     * @param string   $destination      Bodega destino.
+     * @param array    $details          Detalles de productos.
+     * @param string   $movement_context Contexto del movimiento (reserve|restore).
+     *
+     * @return array
+     */
+    protected function build_transfer_payload( WC_Order $order, $source, $destination, array $details, $movement_context ) {
+        $description = 'reserve' === $movement_context
+            ? __( 'Transferencia automática desde WooCommerce para reservar inventario.', 'contifico-woocommerce' )
+            : __( 'Transferencia automática desde WooCommerce para liberar inventario.', 'contifico-woocommerce' );
+
+        if ( method_exists( $order, 'get_order_number' ) ) {
+            $description = sprintf( '%s %s', $description, '#' . $order->get_order_number() );
+        }
+
+        return array(
+            'tipo'              => 'TRA',
+            'fecha'             => function_exists( 'gmdate' ) ? gmdate( 'd/m/Y' ) : date( 'd/m/Y' ),
+            'bodega_id'         => (string) $source,
+            'bodega_destino_id' => (string) $destination,
+            'detalles'          => $details,
+            'descripcion'       => $description,
+        );
+    }
+
+    /**
+     * Obtiene los ajustes necesarios para determinar si se debe actuar.
+     *
+     * @return array
+     */
+    protected function get_transfer_settings() {
+        $settings = $this->settings_manager->get_settings();
+
+        $enabled = isset( $settings['inventory_transfer_enabled'] ) && 'yes' === $settings['inventory_transfer_enabled'];
+        $source  = isset( $settings['inventory_transfer_source'] ) ? $settings['inventory_transfer_source'] : '';
+        $dest    = isset( $settings['inventory_transfer_destination'] ) ? $settings['inventory_transfer_destination'] : '';
+
+        $decrease = isset( $settings['inventory_transfer_decrease_statuses'] ) && is_array( $settings['inventory_transfer_decrease_statuses'] )
+            ? array_map( array( $this, 'normalize_status_key' ), $settings['inventory_transfer_decrease_statuses'] )
+            : array();
+
+        $restore = isset( $settings['inventory_transfer_restore_statuses'] ) && is_array( $settings['inventory_transfer_restore_statuses'] )
+            ? array_map( array( $this, 'normalize_status_key' ), $settings['inventory_transfer_restore_statuses'] )
+            : array();
+
+        if ( '' === $source || '' === $dest || empty( $decrease ) || empty( $restore ) ) {
+            $enabled = false;
+        }
+
+        return array(
+            'enabled'           => $enabled,
+            'source'            => (string) $source,
+            'destination'       => (string) $dest,
+            'decrease_statuses' => $decrease,
+            'restore_statuses'  => $restore,
+        );
+    }
+
+    /**
+     * Recupera el estado almacenado de transferencias para el pedido.
+     *
+     * @param WC_Order $order Pedido consultado.
+     *
+     * @return array
+     */
+    protected function get_transfer_state( WC_Order $order ) {
+        $state = $order->get_meta( self::META_KEY );
+
+        return is_array( $state ) ? $state : array();
+    }
+
+    /**
+     * Normaliza el identificador de estado de pedido para facilitar comparaciones.
+     *
+     * @param string $status Estado a normalizar.
+     *
+     * @return string
+     */
+    protected function normalize_status_key( $status ) {
+        $status = strtolower( (string) $status );
+
+        if ( 0 === strpos( $status, 'wc-' ) ) {
+            $status = substr( $status, 3 );
+        }
+
+        return $status;
+    }
+
+    /**
+     * Envía mensajes al logger cuando está disponible.
+     *
+     * @param string $level   Nivel del mensaje.
+     * @param string $message Contenido a registrar.
+     * @param array  $context Datos adicionales.
+     *
+     * @return void
+     */
+    protected function log( $level, $message, array $context = array() ) {
+        if ( ! $this->logger || ! method_exists( $this->logger, 'log' ) ) {
+            return;
+        }
+
+        $this->logger->log( $level, $message, array_merge( array( 'source' => Contifico_WooCommerce_Api_Contifico_Client::LOG_SOURCE ), $context ) );
+    }
+}

--- a/wp-content/plugins/contifico-woocommerce/includes/class-plugin.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/class-plugin.php
@@ -43,6 +43,13 @@ class Contifico_WooCommerce_Plugin {
     protected $inventory_sync;
 
     /**
+     * Administrador de transferencias automáticas de inventario.
+     *
+     * @var Contifico_WooCommerce_Inventory_Transfer_Manager
+     */
+    protected $inventory_transfer_manager;
+
+    /**
      * Gestor de ajustes del plugin.
      *
      * @var Contifico_WooCommerce_Admin_Settings
@@ -113,19 +120,37 @@ class Contifico_WooCommerce_Plugin {
             return;
         }
 
-        $this->settings       = new Contifico_WooCommerce_Admin_Settings();
-        $this->admin          = new Contifico_WooCommerce_Admin( $this->version, $this->settings );
-        $this->public         = new Contifico_WooCommerce_Public( $this->version );
-        $this->inventory_sync = new Contifico_WooCommerce_Sync_Inventory_Sync();
-        $logger               = function_exists( 'wc_get_logger' ) ? wc_get_logger() : null;
-        $client               = new Contifico_WooCommerce_Api_Contifico_Client( $logger );
-        $this->invoice_manager = new Contifico_WooCommerce_Invoice_Manager( $this->settings, $client, $logger );
+        $this->settings = new Contifico_WooCommerce_Admin_Settings();
+        $this->admin    = new Contifico_WooCommerce_Admin( $this->version, $this->settings );
+        $this->public   = new Contifico_WooCommerce_Public( $this->version );
+
+        $logger = null;
+
+        if ( function_exists( 'wc_get_logger' ) ) {
+            $logger = wc_get_logger();
+        } elseif ( class_exists( 'WC_Logger' ) ) {
+            $logger = new WC_Logger();
+        }
+
+        $client = new Contifico_WooCommerce_Api_Contifico_Client( $logger );
+
+        $this->inventory_sync             = new Contifico_WooCommerce_Sync_Inventory_Sync( $client, $logger, $this->settings );
+        $this->invoice_manager            = new Contifico_WooCommerce_Invoice_Manager( $this->settings, $client, $logger );
+        $this->inventory_transfer_manager = new Contifico_WooCommerce_Inventory_Transfer_Manager( $this->settings, $client, $logger );
+
+        add_action(
+            'update_option_' . Contifico_WooCommerce_Api_Contifico_Client::OPTION_NAME,
+            array( 'Contifico_WooCommerce_Sync_Inventory_Sync', 'maybe_reschedule_cron_on_settings_update' ),
+            10,
+            3
+        );
 
         $this->settings->init();
         $this->admin->init_hooks();
         $this->public->init_hooks();
         $this->inventory_sync->init_hooks();
         $this->invoice_manager->init_hooks();
+        $this->inventory_transfer_manager->init_hooks();
     }
 
     /**

--- a/wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php
+++ b/wp-content/plugins/contifico-woocommerce/includes/sync/class-inventory-sync.php
@@ -84,14 +84,31 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
     protected $logger;
 
     /**
+     * Gestor de ajustes del plugin.
+     *
+     * @var Contifico_WooCommerce_Admin_Settings|null
+     */
+    protected $settings_manager;
+
+    /**
+     * Cache interno de los ajustes cuando no se inyecta el gestor.
+     *
+     * @var array|null
+     */
+    protected $settings_cache;
+
+    /**
      * Constructor.
      *
-     * @param Contifico_WooCommerce_Api_Contifico_Client|null $client Cliente HTTP.
-     * @param WC_Logger|null                                  $logger Logger personalizado.
+     * @param Contifico_WooCommerce_Api_Contifico_Client|null $client   Cliente HTTP.
+     * @param WC_Logger|null                                  $logger   Logger personalizado.
+     * @param Contifico_WooCommerce_Admin_Settings|null       $settings Gestor de ajustes.
      */
-    public function __construct( ?Contifico_WooCommerce_Api_Contifico_Client $client = null, $logger = null ) {
-        $this->client = $client;
-        $this->logger = $logger;
+    public function __construct( ?Contifico_WooCommerce_Api_Contifico_Client $client = null, $logger = null, $settings = null ) {
+        $this->client           = $client;
+        $this->logger           = $logger;
+        $this->settings_manager = $settings;
+        $this->settings_cache   = null;
     }
 
     /**
@@ -105,6 +122,7 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
         add_action( self::BATCH_ACTION, array( $this, 'handle_batch_action' ), 10, 1 );
         add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
         add_action( 'admin_post_contifico_inventory_sync', array( $this, 'handle_admin_post_sync' ) );
+        add_filter( 'cron_schedules', array( $this, 'register_cron_schedules' ) );
     }
 
     /**
@@ -113,13 +131,42 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
      * @return void
      */
     public function schedule_cron() {
+        $schedule = $this->get_schedule_interval();
+
+        if ( '' === $schedule ) {
+            wp_clear_scheduled_hook( self::CRON_HOOK );
+            return;
+        }
+
         if ( wp_next_scheduled( self::CRON_HOOK ) ) {
             return;
         }
 
-        $interval = apply_filters( 'contifico_woocommerce_inventory_sync_interval', 'hourly' );
+        wp_schedule_event( time() + MINUTE_IN_SECONDS, $schedule, self::CRON_HOOK );
+    }
 
-        wp_schedule_event( time() + MINUTE_IN_SECONDS, $interval, self::CRON_HOOK );
+    /**
+     * Registra intervalos personalizados para la sincronización.
+     *
+     * @param array $schedules Intervalos existentes.
+     *
+     * @return array
+     */
+    public function register_cron_schedules( $schedules ) {
+        if ( ! is_array( $schedules ) ) {
+            $schedules = array();
+        }
+
+        $key = 'contifico_woocommerce_every_15_minutes';
+
+        if ( ! isset( $schedules[ $key ] ) ) {
+            $schedules[ $key ] = array(
+                'interval' => 15 * MINUTE_IN_SECONDS,
+                'display'  => __( 'Cada 15 minutos', 'contifico-woocommerce' ),
+            );
+        }
+
+        return $schedules;
     }
 
     /**
@@ -619,6 +666,7 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
                     'nombre'           => $name,
                     'contifico_id'     => $contifico_id,
                     'stock'            => $quantity,
+                    'price'            => isset( $product['price'] ) ? $product['price'] : null,
                 );
             }
 
@@ -733,566 +781,7 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
                 'sku'          => (string) $sku,
                 'name'         => $this->find_value_in_item( $item, array( 'nombre', 'name', 'descripcion', 'description' ) ),
                 'raw'          => $item,
-            );
-        }
-
-        return $products;
-    }
-
-    /**
-     * Busca el primer valor válido dentro de un arreglo utilizando varias claves posibles.
-     *
-     * @param array $item Arreglo de datos.
-     * @param array $keys Claves a evaluar.
-     *
-     * @return string
-     */
-    protected function find_value_in_item( array $item, array $keys ) {
-        foreach ( $keys as $key ) {
-            if ( isset( $item[ $key ] ) && '' !== $item[ $key ] ) {
-                return (string) $item[ $key ];
-            }
-        }
-
-        return '';
-    }
-
-    /**
-     * Convierte la respuesta de stock de Contifico en un mapa por ID de producto.
-     *
-     * @param mixed $response Datos crudos de la API.
-     *
-     * @return array
-     */
-    public function sync_inventory( $context = 'manual' ) {
-        if ( $this->can_use_batch_processing() ) {
-            return $this->start_batch_sync( $context );
-        }
-
-        return $this->run_immediate_inventory_sync( $context );
-    }
-
-    /**
-     * Ejecuta la sincronización de inventario de forma inmediata sin lotes.
-     *
-     * @param string $context Contexto de ejecución.
-     *
-     * @return array|WP_Error
-     */
-    protected function run_immediate_inventory_sync( $context ) {
-        $client = $this->get_client();
-
-
-        if ( isset( $response['results'] ) && is_array( $response['results'] ) ) {
-            $response = $response['results'];
-        } elseif ( isset( $response['data'] ) && is_array( $response['data'] ) ) {
-            $response = $response['data'];
-        }
-
-        if ( ! is_array( $response ) ) {
-            return array();
-        }
-
-        if ( ! $this->is_list( $response ) ) {
-            $response = array( $response );
-        }
-
-        $stock_map = array();
-
-        foreach ( $response as $row ) {
-            if ( ! is_array( $row ) ) {
-                continue;
-            }
-
-            $product_id = $this->find_value_in_item( $row, array( 'producto_id', 'product_id', 'id_producto', 'id' ) );
-
-            if ( '' === $product_id ) {
-                continue;
-            }
-
-            $quantity = $this->find_value_in_item( $row, array( 'cantidad_stock', 'cantidad', 'stock', 'quantity' ) );
-
-            if ( '' === $quantity ) {
-                $quantity = 0;
-            }
-
-            if ( function_exists( 'wc_stock_amount' ) ) {
-                $quantity = wc_stock_amount( $quantity );
-            } else {
-                $quantity = (float) $quantity;
-            }
-
-            $stock_map[ (string) $product_id ] = (float) $quantity;
-        }
-
-        return $stock_map;
-    }
-
-    /**
-     * Finaliza la sincronización por lotes limpiando los productos pendientes y registrando la bitácora.
-     *
-     * @param array $state Estado acumulado de la sincronización.
-     *
-     * @return void
-     */
-    protected function finalize_batch_processing( array $state ) {
-        $context = isset( $state['context'] ) ? $state['context'] : 'manual';
-
-        $cleanup_candidates = array_keys( isset( $state['cleanup_candidates'] ) ? $state['cleanup_candidates'] : array() );
-        $products_cleaned   = isset( $state['products_cleaned'] ) ? (int) $state['products_cleaned'] : 0;
-
-        if ( ! empty( $cleanup_candidates ) ) {
-            $products_cleaned += $this->cleanup_stale_inventory( array_map( 'absint', $cleanup_candidates ), array() );
-        }
-
-        $processed_products = isset( $state['processed_products'] ) && is_array( $state['processed_products'] )
-            ? count( $state['processed_products'] )
-            : 0;
-
-        $summary = array(
-            'warehouses'       => isset( $state['warehouses'] ) && is_array( $state['warehouses'] ) ? count( $state['warehouses'] ) : 0,
-            'products_updated' => $processed_products,
-            'items_processed'  => isset( $state['items_processed'] ) ? (int) $state['items_processed'] : 0,
-            'products_cleaned' => $products_cleaned,
-            'errors'           => isset( $state['errors'] ) && is_array( $state['errors'] ) ? $state['errors'] : array(),
-            'mode'             => 'batch',
-        );
-
-        if ( ! empty( $summary['errors'] ) ) {
-            foreach ( $summary['errors'] as $error_message ) {
-                $this->log( 'warning', $error_message, array( 'context' => $context ) );
-            }
-        }
-
-        $message = sprintf(
-            /* translators: 1: context label, 2: warehouse count, 3: product count */
-            esc_html__( 'Sincronización de inventario %1$s completada. Bodegas procesadas: %2$d. Productos actualizados: %3$d.', 'contifico-woocommerce' ),
-            $this->get_context_label( $context ),
-            isset( $summary['warehouses'] ) ? (int) $summary['warehouses'] : 0,
-            (int) $summary['products_updated']
-        );
-
-        $this->store_log(
-            'success',
-            $message,
-            array_merge(
-                $summary,
-                array(
-                    'context' => $context,
-                )
-            )
-        );
-
-        $this->log( 'info', $message, array( 'context' => $context ) );
-
-        $state['products_cleaned'] = $products_cleaned;
-        $state['finished']         = true;
-
-        $this->clear_batch_state( $state );
-    }
-
-    /**
-     * Inicia la sincronización de inventario en modo por lotes utilizando Action Scheduler.
-     *
-     * @param string $context Contexto desde el cual se ejecuta la sincronización.
-     *
-     * @return array|WP_Error
-     */
-    public function start_batch_sync( $context = 'manual' ) {
-        if ( $this->is_batch_running() ) {
-            $error = new WP_Error(
-                'contifico_inventory_sync_running',
-                esc_html__( 'Ya existe una sincronización de inventario en ejecución.', 'contifico-woocommerce' )
-            );
-
-            $this->log( 'warning', $error->get_error_message(), array( 'context' => $context ) );
-
-            return $error;
-        }
-
-        $client = $this->get_client();
-
-        if ( ! $client ) {
-            $error = new WP_Error(
-                'contifico_missing_client',
-                esc_html__( 'No fue posible inicializar el cliente de Contifico.', 'contifico-woocommerce' )
-            );
-
-            $this->store_log( 'error', $error->get_error_message(), array( 'context' => $context ) );
-
-            return $error;
-        }
-
-        $response = $client->get_warehouses();
-
-        if ( is_wp_error( $response ) ) {
-            $this->log( 'error', $response->get_error_message(), array( 'context' => $context ) );
-            $this->store_log(
-                'error',
-                $response->get_error_message(),
-                array(
-                    'context'    => $context,
-                    'error_code' => $response->get_error_code(),
-                )
-            );
-
-            return $response;
-        }
-
-        $warehouses = $this->normalize_warehouses( $response );
-
-        if ( empty( $warehouses ) ) {
-            return $this->run_immediate_inventory_sync( $context );
-        }
-
-        $prepared_warehouses = array();
-
-        foreach ( $warehouses as $warehouse ) {
-            $warehouse_id = $this->get_warehouse_id( $warehouse );
-
-            if ( '' === $warehouse_id ) {
-                continue;
-            }
-
-            $prepared_warehouses[ $warehouse_id ] = array(
-                'name'             => $this->get_warehouse_name( $warehouse, $warehouse_id ),
-                'stock_cache_key'  => '',
-                'stock_initialized' => false,
-            );
-        }
-
-        if ( empty( $prepared_warehouses ) ) {
-            return $this->run_immediate_inventory_sync( $context );
-        }
-
-        $batch_size = $this->get_batch_size();
-
-        $state = array(
-            'context'            => $context,
-            'batch_size'         => $batch_size,
-            'current_step'       => 1,
-            'started_at'         => current_time( 'timestamp', true ),
-            'warehouses'         => $prepared_warehouses,
-            'cleanup_candidates' => array(),
-            'processed_products' => array(),
-            'items_processed'    => 0,
-            'products_cleaned'   => 0,
-            'errors'             => array(),
-        );
-
-        $existing_inventory = $this->get_products_with_inventory_meta();
-
-        if ( ! empty( $existing_inventory ) ) {
-            $state['cleanup_candidates'] = array_fill_keys( $existing_inventory, true );
-        }
-
-        $this->save_batch_state( $state );
-        $this->enqueue_batch_step( 1 );
-
-        $message = esc_html__( 'Se inició la sincronización de inventario en segundo plano.', 'contifico-woocommerce' );
-
-        $this->log( 'info', $message, array( 'context' => $context ) );
-
-        return array(
-            'message' => $message,
-            'summary' => array(
-                'status'     => 'queued',
-                'warehouses' => count( $prepared_warehouses ),
-                'batch_size' => $batch_size,
-                'context'    => $context,
-            ),
-        );
-    }
-
-    /**
-     * Ejecuta el procesamiento de un lote específico dentro de la sincronización.
-     *
-     * @param int $step Número del lote a procesar.
-     *
-     * @return void
-     */
-    protected function process_batch_step( $step ) {
-        $state = $this->get_batch_state();
-
-        if ( empty( $state ) ) {
-            return;
-        }
-
-        $context    = isset( $state['context'] ) ? $state['context'] : 'manual';
-        $batch_size = isset( $state['batch_size'] ) ? absint( $state['batch_size'] ) : $this->get_batch_size();
-        $batch_size = $batch_size > 0 ? $batch_size : $this->get_batch_size();
-
-        $client = $this->get_client();
-
-        if ( ! $client ) {
-            $error = new WP_Error(
-                'contifico_missing_client',
-                esc_html__( 'No fue posible inicializar el cliente de Contifico.', 'contifico-woocommerce' )
-            );
-
-            $this->log( 'error', $error->get_error_message(), array( 'context' => $context ) );
-            $this->store_log( 'error', $error->get_error_message(), array( 'context' => $context ) );
-            $this->clear_batch_state( $state );
-
-            return;
-        }
-
-        $response = $client->get_items(
-            array(
-                'result_page' => $step,
-                'result_size' => $batch_size,
-            )
-        );
-
-        if ( is_wp_error( $response ) ) {
-            $this->log( 'error', $response->get_error_message(), array( 'context' => $context, 'step' => $step ) );
-            $this->store_log(
-                'error',
-                $response->get_error_message(),
-                array(
-                    'context'    => $context,
-                    'step'       => $step,
-                    'error_code' => $response->get_error_code(),
-                )
-            );
-            $this->clear_batch_state( $state );
-
-            return;
-        }
-
-        $products = $this->normalize_products_batch( $response );
-
-        if ( empty( $products ) ) {
-            $this->finalize_batch_processing( $state );
-            return;
-        }
-
-        $timestamp = current_time( 'mysql', true );
-
-        $warehouses_payload = $this->prepare_warehouses_payload_for_batch( $products, $state, $client );
-
-        $batch_summary = $this->process_inventory_response(
-            $warehouses_payload,
-            array(
-                'clean_stale'        => false,
-                'existing_inventory' => array_keys( isset( $state['cleanup_candidates'] ) ? $state['cleanup_candidates'] : array() ),
-                'timestamp'          => $timestamp,
-            )
-        );
-
-        if ( isset( $batch_summary['items_processed'] ) ) {
-            $state['items_processed'] = isset( $state['items_processed'] )
-                ? (int) $state['items_processed'] + (int) $batch_summary['items_processed']
-                : (int) $batch_summary['items_processed'];
-        }
-
-        if ( isset( $batch_summary['processed_product_ids'] ) && is_array( $batch_summary['processed_product_ids'] ) ) {
-            if ( ! isset( $state['processed_products'] ) || ! is_array( $state['processed_products'] ) ) {
-                $state['processed_products'] = array();
-            }
-
-            foreach ( $batch_summary['processed_product_ids'] as $product_id ) {
-                $product_id = absint( $product_id );
-
-                if ( ! $product_id ) {
-                    continue;
-                }
-
-                $state['processed_products'][ $product_id ] = true;
-
-                if ( isset( $state['cleanup_candidates'][ $product_id ] ) ) {
-                    unset( $state['cleanup_candidates'][ $product_id ] );
-                }
-            }
-        }
-
-        if ( ! empty( $batch_summary['errors'] ) ) {
-            $state['errors'] = isset( $state['errors'] ) && is_array( $state['errors'] )
-                ? array_merge( $state['errors'], $batch_summary['errors'] )
-                : $batch_summary['errors'];
-        }
-
-        $state['current_step'] = $step + 1;
-
-        $this->save_batch_state( $state );
-        $this->enqueue_batch_step( $step + 1 );
-    }
-
-    /**
-     * Construye la carga útil de bodegas para el lote actual.
-     *
-     * @param array                                      $products Productos normalizados devueltos por la API.
-     * @param array                                      $state    Estado actual de la sincronización.
-     * @param Contifico_WooCommerce_Api_Contifico_Client $client   Cliente HTTP de Contifico.
-     *
-     * @return array
-     */
-    protected function prepare_warehouses_payload_for_batch( array $products, array &$state, Contifico_WooCommerce_Api_Contifico_Client $client ) {
-        $payload = array();
-
-        if ( empty( $state['warehouses'] ) || ! is_array( $state['warehouses'] ) ) {
-            return $payload;
-        }
-
-        foreach ( $state['warehouses'] as $warehouse_id => &$warehouse_state ) {
-            $stock_map = $this->get_warehouse_stock_map( $client, $warehouse_id, $warehouse_state );
-
-            if ( is_wp_error( $stock_map ) ) {
-                $error_message = $stock_map->get_error_message();
-
-                if ( ! isset( $state['errors'] ) || ! is_array( $state['errors'] ) ) {
-                    $state['errors'] = array();
-                }
-
-                $state['errors'][] = $error_message;
-
-                $cached_stock_map = false;
-
-                if ( isset( $warehouse_state['stock_cache_key'] ) && '' !== $warehouse_state['stock_cache_key'] ) {
-                    $cached_stock_map = get_transient( $warehouse_state['stock_cache_key'] );
-                }
-
-                if ( false === $cached_stock_map || ! is_array( $cached_stock_map ) ) {
-                    continue;
-                }
-
-                $stock_map = $cached_stock_map;
-            }
-
-            $items = array();
-
-            foreach ( $products as $product ) {
-                $sku          = isset( $product['sku'] ) ? $product['sku'] : '';
-                $contifico_id = isset( $product['contifico_id'] ) ? (string) $product['contifico_id'] : '';
-                $name         = isset( $product['name'] ) ? $product['name'] : '';
-
-                $quantity = 0;
-
-                if ( '' !== $contifico_id && isset( $stock_map[ $contifico_id ] ) ) {
-                    $quantity = $stock_map[ $contifico_id ];
-                }
-
-                $items[] = array(
-                    'sku'              => $sku,
-                    'codigo'           => $sku,
-                    'codigo_principal' => $sku,
-                    'nombre'           => $name,
-                    'contifico_id'     => $contifico_id,
-                    'stock'            => $quantity,
-                );
-            }
-
-            $payload[] = array(
-                'id'     => $warehouse_id,
-                'nombre' => $warehouse_state['name'],
-                'items'  => $items,
-            );
-        }
-
-        return $payload;
-    }
-
-    /**
-     * Obtiene el mapa de stock para una bodega, usando caché temporal cuando es posible.
-     *
-     * @param Contifico_WooCommerce_Api_Contifico_Client $client          Cliente HTTP.
-     * @param string                                     $warehouse_id    Identificador de la bodega.
-     * @param array                                      $warehouse_state Estado almacenado de la bodega.
-     *
-     * @return array|WP_Error
-     */
-    protected function get_warehouse_stock_map( Contifico_WooCommerce_Api_Contifico_Client $client, $warehouse_id, array &$warehouse_state ) {
-        $cache_key = isset( $warehouse_state['stock_cache_key'] ) ? $warehouse_state['stock_cache_key'] : '';
-
-        if ( '' !== $cache_key ) {
-            $cached = get_transient( $cache_key );
-
-            if ( false !== $cached && is_array( $cached ) ) {
-                return $cached;
-            }
-        }
-
-        $response = $client->get_inventory_by_warehouse( $warehouse_id );
-
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
-
-        $stock_map = $this->normalize_stock_response( $response );
-
-        $this->store_stock_cache_for_warehouse( $warehouse_id, $stock_map, $warehouse_state );
-
-        return $stock_map;
-    }
-
-    /**
-     * Guarda en un transient el stock asociado a una bodega.
-     *
-     * @param string $warehouse_id    Identificador de la bodega.
-     * @param array  $stock_map       Mapa de existencias por producto.
-     * @param array  $warehouse_state Estado actual de la bodega.
-     *
-     * @return void
-     */
-    protected function store_stock_cache_for_warehouse( $warehouse_id, array $stock_map, array &$warehouse_state ) {
-        $ttl = apply_filters( 'contifico_woocommerce_inventory_stock_cache_ttl', HOUR_IN_SECONDS );
-
-        if ( isset( $warehouse_state['stock_cache_key'] ) && '' !== $warehouse_state['stock_cache_key'] ) {
-            set_transient( $warehouse_state['stock_cache_key'], $stock_map, $ttl );
-        } else {
-            $key = self::STOCK_CACHE_TRANSIENT_PREFIX . md5( $warehouse_id . '|' . microtime() . '|' . wp_rand() );
-            set_transient( $key, $stock_map, $ttl );
-            $warehouse_state['stock_cache_key'] = $key;
-        }
-
-        $warehouse_state['stock_initialized'] = true;
-    }
-
-    /**
-     * Normaliza la respuesta de productos para trabajar siempre con una lista uniforme.
-     *
-     * @param mixed $response Respuesta de la API de Contifico.
-     *
-     * @return array
-     */
-    protected function normalize_products_batch( $response ) {
-        if ( empty( $response ) ) {
-            return array();
-        }
-
-        if ( isset( $response['results'] ) && is_array( $response['results'] ) ) {
-            $response = $response['results'];
-        } elseif ( isset( $response['data'] ) && is_array( $response['data'] ) ) {
-            $response = $response['data'];
-        }
-
-        if ( ! is_array( $response ) ) {
-            return array();
-        }
-
-        if ( ! $this->is_list( $response ) ) {
-            $response = array( $response );
-        }
-
-        $products = array();
-
-        foreach ( $response as $item ) {
-            if ( ! is_array( $item ) ) {
-                continue;
-            }
-
-            $contifico_id = $this->find_value_in_item( $item, array( 'id', 'producto_id', 'product_id', 'id_producto' ) );
-            $sku          = $this->find_value_in_item( $item, array( 'sku', 'codigo', 'codigo_principal', 'codigo_auxiliar' ) );
-
-            if ( '' === $contifico_id || '' === $sku ) {
-                continue;
-            }
-
-            $products[] = array(
-                'contifico_id' => (string) $contifico_id,
-                'sku'          => (string) $sku,
-                'name'         => $this->find_value_in_item( $item, array( 'nombre', 'name', 'descripcion', 'description' ) ),
-                'raw'          => $item,
+                'price'        => $this->resolve_price_from_item( $item ),
             );
         }
 
@@ -1481,6 +970,7 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
 
         if ( ! empty( $built_inventory['product_map'] ) ) {
             $this->persist_product_metadata( $built_inventory['product_map'] );
+            $this->maybe_sync_product_prices( $built_inventory['product_map'] );
         }
 
         return array(
@@ -1579,6 +1069,12 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
                     );
                 }
 
+                $this->append_price_to_product_map( $product_map, $product_id, $item );
+
+                if ( isset( $item['contifico_id'] ) && '' !== $item['contifico_id'] && isset( $product_map[ $product_id ] ) && ! isset( $product_map[ $product_id ]['contifico_id'] ) ) {
+                    $product_map[ $product_id ]['contifico_id'] = (string) $item['contifico_id'];
+                }
+
                 $grouped_inventory[ $product_id ][ $warehouse_id ] = array(
                     'warehouse_id'   => $warehouse_id,
                     'name'           => $warehouse_name,
@@ -1598,6 +1094,219 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
             'warehouses_count'  => $warehouses_count,
             'items_processed'   => $items_processed,
         );
+    }
+
+    /**
+     * Añade el precio detectado al mapa de productos.
+     *
+     * @param array $product_map Mapa de productos actual.
+     * @param int   $product_id  Identificador del producto.
+     * @param array $item        Datos crudos del inventario.
+     *
+     * @return void
+     */
+    protected function append_price_to_product_map( array &$product_map, $product_id, array $item ) {
+        if ( isset( $product_map[ $product_id ]['price'] ) ) {
+            return;
+        }
+
+        $price = null;
+
+        if ( isset( $item['price'] ) && '' !== $item['price'] ) {
+            $price = $item['price'];
+        } else {
+            $price = $this->resolve_price_from_item( $item );
+        }
+
+        if ( null === $price ) {
+            return;
+        }
+
+        if ( ! isset( $product_map[ $product_id ] ) ) {
+            $product_map[ $product_id ] = array();
+        }
+
+        $product_map[ $product_id ]['price'] = $price;
+    }
+
+    /**
+     * Devuelve la lista de precios seleccionada en la configuración.
+     *
+     * @return string
+     */
+    protected function get_price_list_setting() {
+        $settings = $this->get_settings();
+        $value    = isset( $settings['inventory_price_list'] ) ? $settings['inventory_price_list'] : 'none';
+        $allowed  = array( 'none', 'pvp1', 'pvp2', 'pvp3' );
+
+        if ( ! in_array( $value, $allowed, true ) ) {
+            $value = 'none';
+        }
+
+        return $value;
+    }
+
+    /**
+     * Intenta resolver el precio del producto desde la respuesta del API.
+     *
+     * @param array $item Datos crudos del producto o inventario.
+     *
+     * @return float|null
+     */
+    protected function resolve_price_from_item( array $item ) {
+        $list = $this->get_price_list_setting();
+
+        if ( 'none' === $list ) {
+            return null;
+        }
+
+        $price = null;
+
+        if ( isset( $item['price'] ) && '' !== $item['price'] ) {
+            $price = $item['price'];
+        }
+
+        if ( null === $price && isset( $item['precios'] ) && is_array( $item['precios'] ) ) {
+            $prices = $item['precios'];
+            $candidates = array( $list, strtoupper( $list ), strtolower( $list ) );
+
+            foreach ( $candidates as $candidate ) {
+                if ( isset( $prices[ $candidate ] ) && '' !== $prices[ $candidate ] ) {
+                    $price = $prices[ $candidate ];
+                    break;
+                }
+            }
+        }
+
+        $map = array(
+            'pvp1' => array( 'pvp1', 'precio_pvp1', 'precio1', 'price1', 'pvp_1' ),
+            'pvp2' => array( 'pvp2', 'precio_pvp2', 'precio2', 'price2', 'pvp_2' ),
+            'pvp3' => array( 'pvp3', 'precio_pvp3', 'precio3', 'price3', 'pvp_3' ),
+        );
+
+        if ( null === $price && isset( $map[ $list ] ) ) {
+            foreach ( $map[ $list ] as $key ) {
+                if ( isset( $item[ $key ] ) && '' !== $item[ $key ] ) {
+                    $price = $item[ $key ];
+                    break;
+                }
+            }
+        }
+
+        if ( null === $price ) {
+            foreach ( array( 'precio', 'price', 'precio_unitario', 'valor_unitario' ) as $fallback ) {
+                if ( isset( $item[ $fallback ] ) && '' !== $item[ $fallback ] ) {
+                    $price = $item[ $fallback ];
+                    break;
+                }
+            }
+        }
+
+        if ( null === $price ) {
+            return null;
+        }
+
+        return $this->normalize_price_value( $price );
+    }
+
+    /**
+     * Normaliza un valor numérico para ser utilizado como precio.
+     *
+     * @param mixed $value Valor original.
+     *
+     * @return float|null
+     */
+    protected function normalize_price_value( $value ) {
+        if ( function_exists( 'wc_format_decimal' ) ) {
+            $formatted = wc_format_decimal( $value );
+
+            if ( '' === $formatted ) {
+                return null;
+            }
+
+            $value = (float) $formatted;
+        } else {
+            if ( is_string( $value ) ) {
+                $value = str_replace( array( ' ', ',' ), array( '', '.' ), $value );
+            }
+
+            $value = floatval( $value );
+        }
+
+        if ( $value < 0 ) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Formatea un precio para almacenarlo en WooCommerce.
+     *
+     * @param float $value Valor numérico del precio.
+     *
+     * @return string
+     */
+    protected function format_price_for_product( $value ) {
+        if ( function_exists( 'wc_format_decimal' ) ) {
+            $decimals = function_exists( 'wc_get_price_decimals' ) ? wc_get_price_decimals() : 2;
+            return wc_format_decimal( $value, $decimals );
+        }
+
+        return number_format( $value, 2, '.', '' );
+    }
+
+    /**
+     * Actualiza el precio regular de los productos con la información sincronizada.
+     *
+     * @param array $product_map Mapa de productos procesados.
+     *
+     * @return void
+     */
+    protected function maybe_sync_product_prices( array $product_map ) {
+        if ( 'none' === $this->get_price_list_setting() ) {
+            return;
+        }
+
+        if ( empty( $product_map ) || ! function_exists( 'wc_get_product' ) ) {
+            return;
+        }
+
+        foreach ( $product_map as $product_id => $data ) {
+            $product_id = absint( $product_id );
+
+            if ( ! $product_id || empty( $data['price'] ) ) {
+                continue;
+            }
+
+            $price_value = $this->normalize_price_value( $data['price'] );
+
+            if ( null === $price_value ) {
+                continue;
+            }
+
+            $product = wc_get_product( $product_id );
+
+            if ( ! $product instanceof WC_Product ) {
+                continue;
+            }
+
+            $current_price = $this->normalize_price_value( $product->get_regular_price() );
+
+            if ( null !== $current_price && abs( $current_price - $price_value ) < 0.0001 ) {
+                continue;
+            }
+
+            $formatted_price = $this->format_price_for_product( $price_value );
+
+            if ( method_exists( $product, 'set_regular_price' ) ) {
+                $product->set_regular_price( $formatted_price );
+                $product->save();
+            } else {
+                update_post_meta( $product_id, '_regular_price', $formatted_price );
+                update_post_meta( $product_id, '_price', $formatted_price );
+            }
+        }
     }
 
     /**
@@ -1928,6 +1637,29 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
     }
 
     /**
+     * Obtiene los ajustes almacenados de la integración.
+     *
+     * @return array
+     */
+    protected function get_settings() {
+        if ( $this->settings_manager instanceof Contifico_WooCommerce_Admin_Settings ) {
+            return $this->settings_manager->get_settings();
+        }
+
+        if ( null === $this->settings_cache ) {
+            $stored = get_option( Contifico_WooCommerce_Api_Contifico_Client::OPTION_NAME, array() );
+
+            if ( ! is_array( $stored ) ) {
+                $stored = array();
+            }
+
+            $this->settings_cache = $stored;
+        }
+
+        return $this->settings_cache;
+    }
+
+    /**
      * Obtiene el cliente HTTP configurado.
      *
      * @return Contifico_WooCommerce_Api_Contifico_Client|null
@@ -2077,12 +1809,67 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
     }
 
     /**
+     * Obtiene el intervalo configurado para la sincronización automática.
+     *
+     * @return string
+     */
+    protected function get_schedule_interval() {
+        return self::resolve_schedule_from_settings( $this->get_settings() );
+    }
+
+    /**
+     * Determina el intervalo adecuado a partir de los ajustes disponibles.
+     *
+     * @param array|null $settings Ajustes almacenados.
+     *
+     * @return string
+     */
+    protected static function resolve_schedule_from_settings( $settings = null ) {
+        if ( null === $settings ) {
+            $settings = get_option( Contifico_WooCommerce_Api_Contifico_Client::OPTION_NAME, array() );
+        }
+
+        if ( ! is_array( $settings ) ) {
+            $settings = array();
+        }
+
+        $selected = isset( $settings['inventory_sync_interval'] ) ? $settings['inventory_sync_interval'] : 'hourly';
+
+        $map = array(
+            'manual'     => '',
+            '15min'      => 'contifico_woocommerce_every_15_minutes',
+            'hourly'     => 'hourly',
+            'twicedaily' => 'twicedaily',
+            'daily'      => 'daily',
+        );
+
+        if ( ! isset( $map[ $selected ] ) ) {
+            $selected = 'hourly';
+        }
+
+        $interval = $map[ $selected ];
+
+        if ( '' === $interval ) {
+            return '';
+        }
+
+        return apply_filters( 'contifico_woocommerce_inventory_sync_interval', $interval );
+    }
+
+    /**
      * Determina el tamaño del lote a utilizar durante la sincronización.
      *
      * @return int
      */
     protected function get_batch_size() {
-        $size = apply_filters( 'contifico_woocommerce_inventory_batch_size', self::DEFAULT_BATCH_SIZE );
+        $settings = $this->get_settings();
+        $size     = isset( $settings['inventory_batch_size'] ) ? absint( $settings['inventory_batch_size'] ) : self::DEFAULT_BATCH_SIZE;
+
+        if ( $size <= 0 ) {
+            $size = self::DEFAULT_BATCH_SIZE;
+        }
+
+        $size = apply_filters( 'contifico_woocommerce_inventory_batch_size', $size );
         $size = absint( $size );
 
         if ( $size <= 0 ) {
@@ -2213,15 +2000,51 @@ class Contifico_WooCommerce_Sync_Inventory_Sync {
     }
 
     /**
+     * Reprograma el evento de sincronización según los ajustes recibidos.
+     *
+     * @param array|null $settings Ajustes a utilizar.
+     *
+     * @return void
+     */
+    public static function reschedule_cron( $settings = null ) {
+        wp_clear_scheduled_hook( self::CRON_HOOK );
+
+        $schedule = self::resolve_schedule_from_settings( $settings );
+
+        if ( '' === $schedule ) {
+            return;
+        }
+
+        wp_schedule_event( time() + MINUTE_IN_SECONDS, $schedule, self::CRON_HOOK );
+    }
+
+    /**
+     * Ejecuta la reprogramación del cron cuando se actualizan los ajustes.
+     *
+     * @param mixed $old_value Valor anterior.
+     * @param mixed $value     Valor nuevo.
+     *
+     * @return void
+     */
+    public static function maybe_reschedule_cron_on_settings_update( $old_value, $value, $option = '' ) {
+        if ( '' !== $option && Contifico_WooCommerce_Api_Contifico_Client::OPTION_NAME !== $option ) {
+            return;
+        }
+
+        if ( ! is_array( $value ) ) {
+            return;
+        }
+
+        self::reschedule_cron( $value );
+    }
+
+    /**
      * Programa el evento de sincronización al activar el plugin.
      *
      * @return void
      */
     public static function activate() {
-        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-            $interval = apply_filters( 'contifico_woocommerce_inventory_sync_interval', 'hourly' );
-            wp_schedule_event( time() + MINUTE_IN_SECONDS, $interval, self::CRON_HOOK );
-        }
+        self::reschedule_cron();
     }
 
     /**


### PR DESCRIPTION
## Summary
- add admin options for API logging, inventory scheduling, price list syncing, and warehouse transfer configuration with diagnostics guidance
- implement automatic inventory transfer manager and extend Contifico client logging and transfer helpers
- sync WooCommerce prices during inventory updates, reschedule cron on settings changes, and cover new flows with tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68d390e6a9788332ae8221321b258872